### PR TITLE
Update to new xentore interface in v1.2.3

### DIFF
--- a/xenstore/xenstore.ml
+++ b/xenstore/xenstore.ml
@@ -69,9 +69,9 @@ module Xs = struct
         introduce = Client.introduce h;
         set_target = Client.set_target h;
     }
-    let with_xs f = Client.with_xs (client ()) (fun h -> f (ops h))
+    let with_xs f = Client.immediate (client ()) (fun h -> f (ops h))
     let wait f = Client.wait (client ()) (fun h -> f (ops h))
-	let transaction _ f = Client.with_xst (client ()) (fun h -> f (ops h))
+	let transaction _ f = Client.transaction (client ()) (fun h -> f (ops h))
 
 end
 


### PR DESCRIPTION
We use 'immediate' rather than 'with_xs' and 'transaction'
instead of 'with_xst'

Signed-off-by: David Scott dave.scott@eu.citrix.com
