### PR TITLE
CA-141364: Remove redundant (and erroneous bindings)

### DIFF
--- a/xenctrlext/xenctrlext.ml
+++ b/xenctrlext/xenctrlext.ml
@@ -17,8 +17,6 @@ open Xenctrl
 external get_boot_cpufeatures: handle ->  (int32 * int32 * int32 * int32 * int32 * int32 * int32 * int32) = "stub_xenctrlext_get_boot_cpufeatures" 
 
 external domain_set_timer_mode: handle -> domid -> int -> unit = "stub_xenctrlext_domain_set_timer_mode"
-external domain_set_hpet: handle -> domid -> int -> unit = "stub_xenctrlext_domain_set_hpet"
-external domain_set_vpt_align: handle -> domid -> int -> unit = "stub_xenctrlext_domain_set_vpt_align"
 
 external domain_send_s3resume: handle -> domid -> unit = "stub_xenctrlext_domain_send_s3resume"
 external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_domain_get_acpi_s_state"

--- a/xenctrlext/xenctrlext.mli
+++ b/xenctrlext/xenctrlext.mli
@@ -17,8 +17,6 @@ open Xenctrl
 external get_boot_cpufeatures: handle ->  (int32 * int32 * int32 * int32 * int32 * int32 * int32 * int32) = "stub_xenctrlext_get_boot_cpufeatures" 
 
 external domain_set_timer_mode: handle -> domid -> int -> unit = "stub_xenctrlext_domain_set_timer_mode"
-external domain_set_hpet: handle -> domid -> int -> unit = "stub_xenctrlext_domain_set_hpet"
-external domain_set_vpt_align: handle -> domid -> int -> unit = "stub_xenctrlext_domain_set_vpt_align"
 
 external domain_send_s3resume: handle -> domid -> unit = "stub_xenctrlext_domain_send_s3resume"
 external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_domain_get_acpi_s_state"

--- a/xenctrlext/xenctrlext_stubs.c
+++ b/xenctrlext/xenctrlext_stubs.c
@@ -125,15 +125,6 @@ static int xcext_domain_set_timer_mode(xc_interface *xch, unsigned int domid, in
                             HVM_PARAM_TIMER_MODE, (unsigned long) mode);
 }
 
-static int xcext_domain_set_hpet(xc_interface *xch, unsigned int domid, int hpet)
-{
-	return xc_set_hvm_param(xch, domid, HVM_PARAM_HPET_ENABLED, (unsigned long) hpet);
-}
-static int xcext_domain_set_vpt_align(xc_interface *xch, unsigned int domid, int vpt_align)
-{
-	return xc_set_hvm_param(xch, domid, HVM_PARAM_HPET_ENABLED, (unsigned long) vpt_align);
-}
-
 CAMLprim value stub_xenctrlext_domain_get_acpi_s_state(value xch, value domid)
 {
 	CAMLparam2(xch, domid);
@@ -160,28 +151,6 @@ CAMLprim value stub_xenctrlext_domain_set_timer_mode(value xch, value id, value 
 	int ret;
 
 	ret = xcext_domain_set_timer_mode(_H(xch), _D(id), Int_val(mode));
-	if (ret < 0)
-		failwith_xc(_H(xch));
-	CAMLreturn(Val_unit);
-}
-
-CAMLprim value stub_xenctrlext_domain_set_hpet(value xch, value id, value mode)
-{
-	CAMLparam3(xch, id, mode);
-	int ret;
-
-	ret = xcext_domain_set_hpet(_H(xch), _D(id), Int_val(mode));
-	if (ret < 0)
-		failwith_xc(_H(xch));
-	CAMLreturn(Val_unit);
-}
-
-CAMLprim value stub_xenctrlext_domain_set_vpt_align(value xch, value id, value mode)
-{
-	CAMLparam3(xch, id, mode);
-	int ret;
-
-	ret = xcext_domain_set_vpt_align(_H(xch), _D(id), Int_val(mode));
 	if (ret < 0)
 		failwith_xc(_H(xch));
 	CAMLreturn(Val_unit);


### PR DESCRIPTION
We no longer need these bindings since this work is done in Xenguest. Also, it
appears both of the bindings mistakenly make the same call into libxc.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
