### PR TITLE
CP-13189 TLS ciphersuite TLS_RSA_WITH_AES_128_CBC_SHA

### DIFF
--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -129,7 +129,9 @@ type t = { mutable pid: pid; fd: Unix.file_descr; host: string; port: int;
 
 let config_file verify_cert extended_diagnosis host port legacy =
 
-    let good_ciphers = "!EXPORT:TLSv1.2" in
+    (* This "good" list must match, or at least contain one of, the
+     * GOOD_CIPHERS in xen-api/scripts/init.d-xapissl *)
+    let good_ciphers = "!EXPORT:RSA+AES128-SHA" in
     let back_compat_ciphers = "RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+RC4-MD5:RSA+DES-CBC3-SHA" in
 
 	let lines = [


### PR DESCRIPTION
For outbound connections from XAPI, this commit implements the
recommendation from the Citrix security team that XenServer should
use only ciphersuite TLS_RSA_WITH_AES_128_CBC_SHA for TLSv1.2.

(The exception is when the host ssl-legacy setting is switched on for
backward compatibility).

This recommendation is based on a combination of criteria:
* technical (security) considerations
* legal considerations
* compatibility with third-party TLSv1.2 clients

This commit relies on a corresponding commit in another repository to
set the ciphersuite accepted for incoming connections to xapi, so that
XenServer hosts will be able to communicate with one another.
