### PR TITLE
CP-14531: Configurable stunnel TLS ciphersuites

### DIFF
--- a/stunnel/stunnel.mli
+++ b/stunnel/stunnel.mli
@@ -65,3 +65,7 @@ val must_verify_cert : bool option -> bool
 val set_legacy_protocol_and_ciphersuites_allowed : bool -> unit
 
 val is_legacy_protocol_and_ciphersuites_allowed : unit -> bool
+
+val set_good_ciphersuites : string -> unit
+
+val set_legacy_ciphersuites : string -> unit


### PR DESCRIPTION
Now the Stunnel module needs to have the ciphersuites specified from
outside using set_good_ciphersuites and set_legacy_ciphersuites.
