### PR TITLE
CA-197035: Set a default cyphersuite for outgoing connections

### DIFF
--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -42,7 +42,7 @@ let legacy_protocol_and_ciphersuites_allowed = ref true
 let is_legacy_protocol_and_ciphersuites_allowed () =
 	!legacy_protocol_and_ciphersuites_allowed
 
-let good_ciphersuites = ref None
+let good_ciphersuites = ref (Some "!EXPORT:RSA+AES128-SHA256")
 let legacy_ciphersuites = ref ""
 
 let init_stunnel_path () =


### PR DESCRIPTION
This lets any program using the Stunnel module make outgoing connections
to xapi. At the moment xcp-rrdd does not set any outbound cyphersuites
so it cannot archive rrds.

This is a temporary patch to fix VM shutdown on a slave, pending a
config file based solution.