### PR TITLE
CA-245559: read_body: don't use Buf_io if unnecessary

### DIFF
--- a/http-svr/buf_io.ml
+++ b/http-svr/buf_io.ml
@@ -44,15 +44,12 @@ let fd_of t = t.fd
 
 (* Internal functions *)
 
-(* Return a copy of the data currently in the buffer *)
-let get_data ic =
-  let str = String.sub ic.buf ic.cur (ic.max - ic.cur) in
-  str
+let is_buffer_empty ic = ic.max - ic.cur <= 0
 
 (* Used as a temporary measure while converting from unbuffered to buffered
    I/O in the rest of the software. *)
 let assert_buffer_empty ic = 
-  if get_data ic <> "" then failwith "Buf_io buffer not empty"
+  if not (is_buffer_empty ic) then failwith "Buf_io buffer not empty"
 
 (* Shift the unprocessed data to the beginning of the buffer *)
 let shift ic =

--- a/http-svr/buf_io.mli
+++ b/http-svr/buf_io.mli
@@ -47,8 +47,8 @@ type err =
 exception Line of err
 
 (** {2 Internal functions} *)
+val is_buffer_empty : t -> bool
 val assert_buffer_empty : t -> unit
-val get_data : t -> string
 
 (* val assert_buffer_empty : t -> unit
 val shift : t -> unit

--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -547,7 +547,7 @@ let read_body ?limit req bio =
 	| Some length ->
 		let length = Int64.to_int length in
 		maybe (fun l -> if length > l then raise Client_requested_size_over_limit) limit;
-		if Buf_io.get_data bio = "" then Unixext.really_read_string (Buf_io.fd_of bio) length
+		if Buf_io.is_buffer_empty bio then Unixext.really_read_string (Buf_io.fd_of bio) length
 		else Buf_io.really_input_buf ~timeout:Buf_io.infinite_timeout bio length
 
 module Chunked = struct

--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -547,7 +547,8 @@ let read_body ?limit req bio =
 	| Some length ->
 		let length = Int64.to_int length in
 		maybe (fun l -> if length > l then raise Client_requested_size_over_limit) limit;
-		Buf_io.really_input_buf ~timeout:Buf_io.infinite_timeout bio length
+		if Buf_io.get_data bio = "" then Unixext.really_read_string (Buf_io.fd_of bio) length
+		else Buf_io.really_input_buf ~timeout:Buf_io.infinite_timeout bio length
 
 module Chunked = struct
     type t = { mutable current_size : int; mutable current_offset : int;


### PR DESCRIPTION
In read_body, if we know the length we want to read, just read it. This avoids
the possibility of reading too much in Buf_io.really_input_buf and accidentally
discarding the excess.

Signed-off-by: Jonathan Davies <jonathan.davies@citrix.com>