### PR TITLE
http-svr: add 500 Internal Server Error HTTP status code

### DIFF
--- a/http-svr/http.ml
+++ b/http-svr/http.ml
@@ -61,6 +61,11 @@ let http_400_badrequest ?(version="1.1") () =
       "Connection: close";
       "Cache-Control: no-cache, no-store" ]
 
+let http_500_internal_server_error ?(version="1.0") () =
+  [ Printf.sprintf "HTTP/%s 500 Internal Server Error" version;
+    "Connection: close";
+    "Cache-Control: no-cache, no-store" ]
+
 let http_501_method_not_implemented ?(version="1.0") () =
   [ Printf.sprintf "HTTP/%s 501 Method Not Implemented" version;
     "Connection: close";

--- a/http-svr/http.mli
+++ b/http-svr/http.mli
@@ -139,6 +139,7 @@ val http_200_ok_with_content : int64 -> ?version:string -> ?keep_alive:bool -> u
 val http_302_redirect : ?version:string -> string -> string list
 val http_404_missing : ?version:string -> unit -> string list
 val http_400_badrequest : ?version:string -> unit -> string list
+val http_500_internal_server_error : ?version:string -> unit -> string list
 val http_501_method_not_implemented : ?version:string -> unit -> string list
 
 module Hdr : sig


### PR DESCRIPTION
This is for use in https://github.com/xapi-project/xen-api/pull/3105 . And in general, I think in all our HTTP handlers, we should have a catch-all case to catch all unmatched exceptions and return this status code there. This would make sure that the client is notified when a random exception happens that we do not explicitly handle. Not responding to the client in case of an error could cause it to hang, see CA-253489 and CA-226886.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>