### PR TITLE
http-svr: use fields with the right semantics

### DIFF
--- a/http-svr/client_server_test.sh
+++ b/http-svr/client_server_test.sh
@@ -1,0 +1,9 @@
+set -eux
+
+trap 'kill $(jobs -p)' EXIT
+
+./test_server.exe &
+sleep 1
+
+./test_client.exe
+

--- a/http-svr/http.ml
+++ b/http-svr/http.ml
@@ -408,7 +408,7 @@ module Request = struct
 
   let get_version x = x.version
 
-  let of_request_line x = match Astring.String.fields x with
+  let of_request_line x = match Astring.String.fields ~empty:false x with
     | [ m; uri; version ] ->
       (* Request-Line   = Method SP Request-URI SP HTTP-Version CRLF *)
       let uri, query = parse_uri uri in

--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -356,7 +356,7 @@ let request_of_bio_exn bio =
   snd(List.fold_left
         (fun (status, req) header ->
            if not status then begin
-             match Astring.String.fields header with
+             match Astring.String.fields ~empty:false header with
              | [ meth; uri; version ] ->
                (* Request-Line   = Method SP Request-URI SP HTTP-Version CRLF *)
                let uri, query = Http.parse_uri uri in

--- a/http-svr/jbuild
+++ b/http-svr/jbuild
@@ -83,4 +83,11 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (deps (radix_tree_test.exe))
   (action (run ${<}))
  ))
+
+
+(alias
+ ((name runtest)
+  (deps (test_client.exe test_server.exe client_server_test.sh))
+  (action (run bash client_server_test.sh))
+ ))
 |} flags

--- a/http-svr/mime.ml
+++ b/http-svr/mime.ml
@@ -25,7 +25,7 @@ let mime_of_file file =
   let h = Hashtbl.create 1024 in
   Xapi_stdext_unix.Unixext.readfile_line (fun line ->
       if not (Astring.String.is_prefix ~affix:"#" line) then begin
-        match Astring.String.fields line with
+        match Astring.String.fields ~empty:false line with
         | [] | [_] -> ()
         | mime::exts ->
           List.iter (fun e ->


### PR DESCRIPTION
As done in `http_client.ml:69`

These changes were added to the PR later and not pushed to the internal branch,
so they were not part of the tested library. This was breaking the parsing of the
http headers in `http_svr.ml`.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>