### PR TITLE
xml-light2: fix typo after refactoring

### DIFF
--- a/xml-light2/xml.ml
+++ b/xml-light2/xml.ml
@@ -100,7 +100,7 @@ let esc_pcdata data =
   let buf = Buffer.create (String.length data + 10) in
   String.iter (fun c ->
       let s = match c with
-        | '>'    -> "&gt;;"
+        | '>'    -> "&gt;"
         | '<'    -> "&lt;"
         | '&'    -> "&amp;"
         | '"'    -> "&quot;"


### PR DESCRIPTION
This should hopefully solve the remaining issues.

It's annoying that `xml-light2` does not have unit tests, but if we drop the necessity of the xapi-client `Legacy` module, we can drop `xml-light2` as well. So I will not spend time on the tests for the moment.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>