### PR TITLE
CA-285840: Make sure stunnel doesn't hang talking to dead hosts

### DIFF
--- a/http-svr/xmlrpc_client.mli
+++ b/http-svr/xmlrpc_client.mli
@@ -92,4 +92,9 @@ module Internal : sig
       		is called to allow us to forget the association between a task and an
       		stunnel pid *)
   val unset_stunnelpid_callback : (string option -> int -> unit) option ref
+
+  (** Callback to check whether a destination address is still OK. Only called after
+      a failed attempt to talk to the destination *)
+  val destination_is_ok : (string -> bool) option ref
+
 end


### PR DESCRIPTION
It would be way better to be using select rather than blocking
reads, but that's a much bigger change and this will need to be
backported.

Also there's a new mechanism for breaking out of the retry loop
if a host has been marked as dead, which will require a change
in xapi to be used.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>