### PR TITLE
CA-296532: mpathalert log spam

### DIFF
--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -21,6 +21,8 @@ open D
 
 module E = Debug.Make(struct let name = "mscgen" end)
 
+let () = Debug.disable ~level:Syslog.Debug "mscgen"
+
 module Internal = struct
   let set_stunnelpid_callback : (string option -> int -> unit) option ref = ref None
   let unset_stunnelpid_callback : (string option -> int -> unit) option ref = ref None


### PR DESCRIPTION
Disable debug log level for brand 'mscgen'

Signed-off-by: Min Li <min.li1@citrix.com>