### PR TITLE
allow_failures cannot be parsed by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ env:
     matrix:
         - BASE_REMOTE=git://github.com/xapi-project/xs-opam REVDEPS=true
         - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
-    matrix:
-        fast_finish: true
-        allow_failures:
-            - env: EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
-
+matrix:
+    fast_finish: true
+    allow_failures:
+        - env: EXTRA_REMOTES=git://github.com/xapi-project/xs-opam


### PR DESCRIPTION
```
export allow_failures=[{:env=>
/home/travis/.travis/job_stages: eval: line 104: syntax error near unexpected token `newline'
/home/travis/.travis/job_stages: eval: line 104: `export allow_failures=[{:env=>
```

Although we use it the way it is documented here: https://docs.travis-ci.com/user/customizing-the-build/

Looks like they were just indented incorrectly
