### PR TITLE
maintenance: remove use of xapi-stdext-base64

### DIFF
--- a/http-svr.opam
+++ b/http-svr.opam
@@ -13,10 +13,10 @@ depends: [
   "ocaml"
   "dune" {build}
   "astring"
+  "base64" {>= "3.1.0"}
   "rpc"
   "sha"
   "stunnel"
-  "xapi-stdext-base64"
   "xapi-stdext-date"
   "xapi-stdext-monadic"
   "xapi-stdext-pervasives"

--- a/http-svr/dune
+++ b/http-svr/dune
@@ -6,11 +6,11 @@
   (modules (:standard \ http_test radix_tree_test test_client test_server))
   (preprocess (pps ppx_deriving_rpc))
   (libraries  astring
+              base64
               rpclib
               sha
               stunnel
               threads
-              xapi-stdext-base64
               xapi-stdext-date
               xapi-stdext-monadic
               xapi-stdext-pervasives

--- a/http-svr/http.ml
+++ b/http-svr/http.ml
@@ -158,15 +158,16 @@ let authorization_of_string x =
   then
     let end_of_string s from =
       String.sub s from ((String.length s)-from) in
-    let userpass = Xapi_stdext_base64.Base64.decode (end_of_string x (String.length basic)) in
-    match Astring.String.cuts ~sep:":" userpass with
-    | [ username; password ] -> Basic(username, password)
-    | _ -> UnknownAuth x
+    match Base64.decode (end_of_string x (String.length basic)) with
+    | Result.Ok userpass -> (match Astring.String.cuts ~sep:":" userpass with
+      | [ username; password ] -> Basic(username, password)
+      | _ -> UnknownAuth x)
+    | Result.Error _ -> UnknownAuth x
   else UnknownAuth x
 
 let string_of_authorization = function
   | UnknownAuth x -> x
-  | Basic(username, password) -> "Basic " ^ (Xapi_stdext_base64.Base64.encode (username ^ ":" ^ password))
+  | Basic(username, password) -> "Basic " ^ (Base64.encode_string (username ^ ":" ^ password))
 
 type method_t = Get | Post | Put | Connect | Options | Unknown of string [@@deriving rpc]
 

--- a/http-svr/ws_helpers.ml
+++ b/http-svr/ws_helpers.ml
@@ -88,7 +88,7 @@ let v10_upgrade req s =
   let key = find_header headers "sec-websocket-key" in
   (*let vsn = find_header headers "sec-websocket-version" in*)
   let result = key ^ ws_uuid |> Sha1.string |> Sha1.to_bin in
-  let key = Xapi_stdext_base64.Base64.encode result in 
+  let key = Base64.encode_string result in
   let headers = http_101_websocket_upgrade_15 key in
   Http.output_http s headers
 


### PR DESCRIPTION
Instead use base64 >= 3.1.0

This causes the parsing code to be more strict: instead of ignoring control characters on the base64 encoded auth token they produce an unknown auth object.

This allows us to drop xapi-stdext-base64 from the codebase

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>