### PR TITLE
Mute Dune preprocess warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ env:
     - PACKAGE=xapi-libs-transitional
     - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
   matrix:
-    - DISTRO="debian-9-ocaml-4.07"
+    - DISTRO="debian-unstable"

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
-(lang dune 1.4)
+(lang dune 1.9)
+(allow_approximate_merlin)

--- a/http-svr.opam
+++ b/http-svr.opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {build}
   "astring"
   "base64" {>= "3.1.0"}
-  "rpc"
+  "rpclib"
   "sha"
   "stunnel"
   "xapi-stdext-date"


### PR DESCRIPTION
This mutes warnings from Dune like the following:

```
dune build --profile=release
File "xen-api-libs-transitional/http-svr/dune", line 7, characters 14-36:
7 |   (preprocess (pps ppx_deriving_rpc))
                  ^^^^^^^^^^^^^^^^^^^^^^
Warning: .merlin generated is inaccurate. Cannot mix preprocessed and non preprocessed specificiations.
```

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>