### PR TITLE
CA-329107: Improve the order of cipher suites for stunnel

### DIFF
--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -43,7 +43,7 @@ let legacy_protocol_and_ciphersuites_allowed = ref false
 let is_legacy_protocol_and_ciphersuites_allowed () =
   !legacy_protocol_and_ciphersuites_allowed
 
-let good_ciphersuites = ref (Some "!EXPORT:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-GCM-SHA384:AES256-SHA256:AES128-SHA256")
+let good_ciphersuites = ref (Some "!EXPORT:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:AES256-SHA256:AES128-SHA256")
 let legacy_ciphersuites = ref "RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+DES-CBC3-SHA"
 
 let init_stunnel_path () =


### PR DESCRIPTION
This commit reverses the order of cipher suites from
"ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
to
"ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384".

The reason is that GCM is more secure than CBC (which is used in
CDHE-RSA-AES256-SHA384).