### PR TITLE
CP-32124: Upgrade stunnel from 4.56 to 5.55

### DIFF
--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -161,7 +161,9 @@ let config_file verify_cert extended_diagnosis host port legacy =
       ["verify=2"
       ; sprintf "checkHost=%s" host
       ; sprintf "CAfile=%s" certificates_bundle_path
-      ; sprintf "CRLpath=%s" crl_path
+      ; (match Sys.readdir crl_path with
+         | [| |] -> ""
+         | _ -> sprintf "CRLpath=%s" crl_path)
       ]
     else []
   ; if legacy then

--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -159,6 +159,7 @@ let config_file verify_cert extended_diagnosis host port legacy =
   ; if extended_diagnosis then ["debug=4"] else []
   ; if verify_cert then
       ["verify=2"
+      ; sprintf "checkHost=%s" host
       ; sprintf "CAfile=%s" certificates_bundle_path
       ; sprintf "CRLpath=%s" crl_path
       ]

--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -155,7 +155,7 @@ let config_file verify_cert extended_diagnosis host port legacy =
       Some x -> Printf.sprintf "TIMEOUTidle = %d" x)
     ; Printf.sprintf "connect=%s:%d" host port
     ]
-  ; if is_fips then [] else ["fips=no"]
+  ; if is_fips then ["fips=yes"] else ["fips=no"]
   ; if extended_diagnosis then ["debug=4"] else []
   ; if verify_cert then
       ["verify=2"


### PR DESCRIPTION
This is part of change to upgrade stunnel from 4.56 to 5.55. There are 3 changes in this PR:
1. Set fips=yes explicitly
2. Add checkHost verify peer hostname against cert
3. Check if the CRLpath is an empty directory