### PR TITLE
CA-336258: http-svr: add JSONRPC_protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
 script: bash -ex .travis-docker.sh
 env:
   global:
-    - PINS="gzip:. http-svr:. pciutil:. sexpr:. sha1:. stunnel:. uuid:. xapi-compression:. xapi-libs-transitional:. xenctrlext:. xml-light2:. zstd:."
+    - PINS="gzip:. http-svr:. pciutil:. sexpr:. stunnel:. uuid:. xapi-compression:. xapi-libs-transitional:. xenctrlext:. xml-light2:. zstd:."
     - PACKAGE=xapi-libs-transitional

--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -357,6 +357,15 @@ module XMLRPC = struct
   let request_to_short_string x = x.Rpc.name
 end
 
+module JSONRPC = struct
+  type response = Rpc.response
+  let response_of_string x = Jsonrpc.response_of_string x
+  let response_of_file_descr fd = Jsonrpc.response_of_in_channel (Unix.in_channel_of_descr fd)
+  type request = Rpc.call
+  let request_to_string x = Jsonrpc.string_of_call x
+  let request_to_short_string x = x.Rpc.name
+end
+
 module Protocol = functor(F: FORMAT) -> struct
   (** Take an optional content_length and task_id together with a socket
       		and return the XMLRPC response as an XML document *)
@@ -381,7 +390,5 @@ end
 
 module XML_protocol = Protocol(XML)
 module XMLRPC_protocol = Protocol(XMLRPC)
-
-
-
+module JSONRPC_protocol = Protocol(JSONRPC)
 

--- a/http-svr/xmlrpc_client.mli
+++ b/http-svr/xmlrpc_client.mli
@@ -80,6 +80,16 @@ module XMLRPC_protocol : sig
   val rpc : ?srcstr:string -> ?dststr:string -> transport:transport -> http:Http.Request.t -> Rpc.call -> Rpc.response
 end
 
+module JSONRPC_protocol : sig
+  (** Functions for handling HTTP/JSONRPC *)
+
+  (** [read_response r fd] returns the response from [fd] given HTTP request [r] *)
+  val read_response : Http.Response.t -> Unix.file_descr -> Rpc.response
+
+  (** [rpc transport http call] sends [call] and returns the result *)
+  val rpc : ?srcstr:string -> ?dststr:string -> transport:transport -> http:Http.Request.t -> Rpc.call -> Rpc.response
+end
+
 module Internal : sig
   (** Internal functions should not be used by clients directly *)
 


### PR DESCRIPTION
I've put this into xmlrpc_client.ml(i), alongside `XML_protocol` and
`XMLRPC_protocol`. The filename does not really make sense anymore, but
changing it would cause a lot of updates (it is used all over the place). And
`XML_protocol` us not XMLRPC either... Not worth doing for a "legacy" module.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>