### PR TITLE
ci: do not pin xenctrlext when running travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
 script: bash -ex .travis-docker.sh
 env:
   global:
-    - PINS="gzip:. http-svr:. pciutil:. sexpr:. stunnel:. uuid:. xapi-compression:. xapi-libs-transitional:. xenctrlext:. xml-light2:. zstd:. safe-resources:."
+    - PINS="gzip:. http-svr:. pciutil:. sexpr:. stunnel:. uuid:. xapi-compression:. xapi-libs-transitional:. xml-light2:. zstd:. safe-resources:."
     - PACKAGE=xapi-libs-transitional

--- a/xml-light2.opam
+++ b/xml-light2.opam
@@ -12,12 +12,6 @@ depends: [
   "dune" {build}
   "xmlm"
 ]
-depexts: [
-  ["libxen-dev"] {os-distribution = "debian"}
-  ["libxen-dev"] {os-distribution = "ubuntu"}
-  ["xen-devel"] {os-distribution = "centos"}
-  ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
-]
 synopsis: "Further transitional libraries required by xapi"
 description: """
 These libraries are provided for backwards compatibility only.


### PR DESCRIPTION
We missed this one on #80. Not sure how the tests [passed](https://travis-ci.org/github/xapi-project/xen-api-libs-transitional/builds/705425605) for the PR.