### PR TITLE
Remove stdext's monadic usages

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,9 @@
+profile=ocamlformat
+version=0.14.1
+indicate-multiline-delimiters=closing-on-separate-line
+if-then-else=fit-or-vertical
+dock-collection-brackets=true
+break-struct=natural
+break-separators=before
+break-infix=fit-or-vertical
+break-infix-before-func=false

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 PROFILE=release
 
-
-.PHONY: build install uninstall clean test doc reindent
+.PHONY: build install uninstall clean test doc format
 
 build:
 	dune build @install --profile=$(PROFILE)
@@ -22,5 +21,5 @@ test:
 doc:
 	dune build @doc --profile=$(PROFILE)
 
-reindent:
-	git ls-files '*.ml' '*.mli' | xargs ocp-indent --inplace
+format:
+	dune build @fmt --auto-promote

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
-(lang dune 1.9)
+(lang dune 1.11)
 (allow_approximate_merlin)
+(using fmt 1.2 (enabled_for ocaml))

--- a/http-svr.opam
+++ b/http-svr.opam
@@ -18,7 +18,6 @@ depends: [
   "sha"
   "stunnel"
   "xapi-stdext-date"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
   "xapi-stdext-unix"

--- a/http-svr/buf_io.ml
+++ b/http-svr/buf_io.ml
@@ -21,9 +21,11 @@ type t =
     mutable max : int;
   }
 
-type err = 
-    Too_long             (* Line input is > 1024 chars *)
-  | No_newline           (* EOF found, with no newline *)
+type err =
+  | (* Line input is > 1024 chars *)
+      Too_long
+  | (* EOF found, with no newline *)
+      No_newline
 
 exception Timeout        (* Waited too long for data to appear *)
 exception Eof           
@@ -35,7 +37,8 @@ let infinite_timeout = -1.
 let of_fd fd =
   (* Unix.set_nonblock fd;*)
   { fd = fd;
-    buf = Bytes.create 1024; (* FIXME -- this should be larger. Low for testing *)
+    (* FIXME -- this should be larger. Low for testing *)
+    buf = Bytes.create 1024;
     cur = 0;
     max = 0;
   }

--- a/http-svr/buf_io.mli
+++ b/http-svr/buf_io.mli
@@ -47,6 +47,7 @@ type err =
 exception Line of err
 
 (** {2 Internal functions} *)
+
 val is_buffer_empty : t -> bool
 val assert_buffer_empty : t -> unit
 

--- a/http-svr/dune
+++ b/http-svr/dune
@@ -13,7 +13,6 @@
               threads
               xapi-idl.updates
               xapi-stdext-date
-              xapi-stdext-monadic
               xapi-stdext-pervasives
               xapi-stdext-threads
               xapi-stdext-unix
@@ -25,7 +24,7 @@
   (modules http_test)
   (libraries  http-svr
               oUnit
-              xapi-stdext-monadic)
+              )
 )
 
 (executable

--- a/http-svr/http.mli
+++ b/http-svr/http.mli
@@ -33,9 +33,11 @@ val read_http_response_header: bytes -> Unix.file_descr -> int
 
 module Accept : sig
   type t = {
-    ty: string option; (* None means '*' *)
-    subty: string option; (* None means '*' *)
-    q: int;
+    (* None means '*' *)
+    ty: string option;
+    (* None means '*' *)
+    subty: string option;
+    q: int
   }
   exception Parse_failure of string
   val t_of_string : string -> t

--- a/http-svr/http_proxy.ml
+++ b/http-svr/http_proxy.ml
@@ -16,7 +16,6 @@ module D=Debug.Make(struct let name="http_proxy" end)
 open D
 
 open Xmlrpc_client
-open Xapi_stdext_monadic
 open Xapi_stdext_threads.Threadext
 open Xapi_stdext_pervasives.Pervasiveext
 
@@ -34,7 +33,7 @@ let one request fromfd s =
       | _ -> request.Http.Request.content_length in
     let (_: int64) = Unixext.copy_file ?limit fromfd s in
     (* Receive response headers from master *)
-    let response = Opt.default Http.Response.internal_error (Http_client.response_of_fd s) in
+    let response = Option.value ~default:Http.Response.internal_error (Http_client.response_of_fd s) in
     (* Transmit response headers to client *)
     Unixext.really_write_string fromfd (Http.Response.to_wire_string response);
     if response.Http.Response.code = "200" then begin
@@ -49,14 +48,14 @@ let one request fromfd s =
 let server = ref None
 let m = Mutex.create ()
 
-let http_proxy src_ip src_port transport = 
+let http_proxy src_ip src_port transport =
   let tcp_connection _ fromfd =
     (* NB 'fromfd' is accepted within the server_io module and it expects us to close it *)
     finally
       (fun () ->
          let bio = Buf_io.of_fd fromfd in
          let request = Http_svr.request_of_bio bio in
-         Opt.iter
+         Option.iter
            (fun request ->
               with_transport transport (one request fromfd)
            ) request;

--- a/http-svr/http_test.ml
+++ b/http-svr/http_test.ml
@@ -14,20 +14,19 @@
 
 open OUnit2
 open Http
-open Xapi_stdext_monadic
 
 let test_accept_simple _ =
   let t = Accept.t_of_string "application/json" in
-  assert_equal ~msg:"ty" ~printer:(Opt.default "None") t.Accept.ty (Some "application");
-  assert_equal ~msg:"subty" ~printer:(Opt.default "None") t.Accept.subty (Some "json");
+  assert_equal ~msg:"ty" ~printer:(Option.value ~default:"None") t.Accept.ty (Some "application");
+  assert_equal ~msg:"subty" ~printer:(Option.value ~default:"None") t.Accept.subty (Some "json");
   assert (Accept.matches ("application", "json") t)
 
 let test_accept_complex _ =
   let ts = Accept.ts_of_string "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8" in
   let m = Accept.preferred_match ("text", "html") ts in
-  assert((Opt.unbox m).Accept.ty = Some "text");
+  assert((Option.get m).Accept.ty = Some "text");
   let m = Accept.preferred_match ("foo", "bar") ts in
-  assert((Opt.unbox m).Accept.ty = None)
+  assert((Option.get m).Accept.ty = None)
 
 let test_strings = [
   "/import_vdi";
@@ -125,7 +124,7 @@ let test_url _ =
   begin match of_string "https://xapi.xen.org/services/SM?foo=bar" with
     | Http t, { uri = "/services/SM"; query_params = [ "foo", "bar" ] } ->
       assert (t.ssl = true);
-      assert (t.host = "xapi.xen.org");			
+      assert (t.host = "xapi.xen.org");
     | _ -> assert false
   end;
   begin
@@ -135,7 +134,7 @@ let test_url _ =
     assert (s = "https://xapi.xen.org/services/SM/data?foo=bar")
   end
 let _ =
-  let suite = "HTTP test" >::: 
+  let suite = "HTTP test" >:::
               [
                 "accept_simple" >:: test_accept_simple;
                 "accept_complex" >:: test_accept_complex;

--- a/http-svr/radix_tree.ml
+++ b/http-svr/radix_tree.ml
@@ -76,10 +76,9 @@ let better acc = function | None -> acc | Some x -> Some x
 let longest_prefix str t = fold_over_path better str None t
 
 let fold f acc t =
-  let open Xapi_stdext_monadic in
   let rec inner p acc = function
     | Node (p', v, ns) ->
       let pp = p ^ p' in
-      let acc = Opt.default acc (Opt.map (fun v -> f pp v acc) v) in
+      let acc = Option.fold ~none:acc ~some:(fun v -> f pp v acc) v in
       List.fold_left (fun acc n -> inner pp acc n) acc ns in
   inner "" acc t

--- a/stunnel.opam
+++ b/stunnel.opam
@@ -12,7 +12,6 @@ depends: [
   "dune" {build}
   "forkexec"
   "safe-resources"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
   "xapi-stdext-unix"

--- a/stunnel/dune
+++ b/stunnel/dune
@@ -10,7 +10,6 @@
              ptime
              logs.fmt
              safe-resources
-             xapi-stdext-monadic
              xapi-stdext-pervasives
              xapi-stdext-threads
              xapi-stdext-unix


### PR DESCRIPTION
I've also included the configuration to use ocamlformat so we can format code when we deem necessary,