### PR TITLE
CA-342856 don't print to stderr, use Debug.error

### DIFF
--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -406,7 +406,7 @@ let request_of_bio ?(use_fastpath=false) ic =
 *)
     Some r
   with e ->
-    D.error "%s (%s)" (Printexc.to_string e) __LOC__;
+    D.warn "%s (%s)" (Printexc.to_string e) __LOC__;
     best_effort (fun () ->
         let ss = Buf_io.fd_of ic in
         match e with

--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -406,7 +406,7 @@ let request_of_bio ?(use_fastpath=false) ic =
 *)
     Some r
   with e ->
-    Printf.fprintf stderr "%s" (Printexc.to_string e);
+    D.error "%s (%s)" (Printexc.to_string e) __LOC__;
     best_effort (fun () ->
         let ss = Buf_io.fd_of ic in
         match e with


### PR DESCRIPTION
The HTTP server prints to stderr but should never do that and use a
logging function. We suspect that this is causing CA-342856.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>