### PR TITLE
CP-35026 parse stunnel PROXY header in http-svr

### DIFF
--- a/http-svr/http.mli
+++ b/http-svr/http.mli
@@ -27,8 +27,9 @@ type authorization =
   | UnknownAuth of string
 
 val read_http_header: bytes -> Unix.file_descr -> int
+val make_frame_header: string -> string
 
-val read_http_request_header: bytes -> Unix.file_descr -> int * bool
+val read_http_request_header: Unix.file_descr -> bool * string * string option
 val read_http_response_header: bytes -> Unix.file_descr -> int
 
 module Accept : sig

--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -344,10 +344,7 @@ let request_of_bio_exn_slow ic =
 
 let request_of_bio_exn bio =
   let fd = Buf_io.fd_of bio in
-
-  let buf = Bytes.create 1024 in
-  let b, frame = Http.read_http_request_header buf fd in
-  let buf = Bytes.sub_string buf 0 b in
+  let frame, headers, proxy = Http.read_http_request_header fd in
 (*
 	Printf.printf "parsed = [%s]\n" buf;
 	flush stdout;
@@ -393,7 +390,7 @@ let request_of_bio_exn bio =
                end
              | None -> true, req (* end of headers *)
            end
-        ) (false, { empty with Http.Request.frame = frame }) (Astring.String.cuts ~sep:"\n" buf))
+        ) (false, { empty with Http.Request.frame = frame }) (Astring.String.cuts ~sep:"\n" headers))
 
 (** [request_of_bio ic] returns [Some req] read from [ic], or [None]. If [None] it will have
     	already sent back a suitable error code and response to the client. *)


### PR DESCRIPTION
Here we propagate PROXY information in request headers into values of type `Http.Request.t`. We expect the PROXY header to be added by stunnel in the HTTPS case, whenever we set `protocol = proxy` 