### PR TITLE
Expose cert verification from stunnel library via global flag

### DIFF
--- a/stunnel.opam
+++ b/stunnel.opam
@@ -11,6 +11,7 @@ depends: [
   "ocaml"
   "dune" {build}
   "forkexec"
+  "ipaddr"
   "safe-resources"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"

--- a/stunnel/dune
+++ b/stunnel/dune
@@ -4,12 +4,13 @@
   (wrapped false)
   (flags (:standard -w -37))
   (libraries astring
-             forkexec
-             threads
              fmt
-             ptime
+             forkexec
+             ipaddr
              logs.fmt
+             ptime
              safe-resources
+             threads
              xapi-stdext-pervasives
              xapi-stdext-threads
              xapi-stdext-unix

--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -135,8 +135,8 @@ let config_file verify_cert extended_diagnosis host port =
   ; if is_fips then ["fips=yes"] else ["fips=no"]
   ; if extended_diagnosis then ["debug=authpriv.7"] else ["debug=authpriv.5"]
   ; if verify_cert then
-      ["verify=2"
-      ; sprintf "checkHost=%s" host
+      ["verifyChain=yes"
+      ; if Ipaddr.of_string host |> Stdlib.Result.is_ok then sprintf "checkIP=%s" host else sprintf "checkHost=%s" host
       ; sprintf "CAfile=%s" certificates_bundle_path
       ; (match Sys.readdir crl_path with
          | [| |] -> ""

--- a/stunnel/stunnel.mli
+++ b/stunnel/stunnel.mli
@@ -38,6 +38,9 @@ type t = { mutable pid: pid;
            verified: bool;
          }
 
+val set_verify_tls_certs : bool -> unit
+val get_verify_tls_certs : unit -> bool
+
 (** Connects via stunnel (optionally via an external 'fork/exec' helper) to
     a host and port.
     NOTE: this does not guarantee the connection to the remote server actually works.
@@ -47,7 +50,6 @@ val with_connect :
   ?unique_id:int ->
   ?use_fork_exec_helper:bool ->
   ?write_to_log:(string -> unit) ->
-  ?verify_cert:bool ->
   ?extended_diagnosis:bool ->
   string -> int -> (t -> 'b) -> 'b
 
@@ -57,8 +59,6 @@ val disconnect : ?wait:bool -> ?force:bool -> t -> unit
 val diagnose_failure : t -> unit
 
 val test : string -> int -> unit
-
-val must_verify_cert : bool option -> bool
 
 val move_out_exn : t -> t
 

--- a/stunnel/stunnel_cache.mli
+++ b/stunnel/stunnel_cache.mli
@@ -26,14 +26,14 @@
     will be used, otherwise we make a fresh one. *)
 val with_connect :
   ?use_fork_exec_helper:bool ->
-  ?write_to_log:(string -> unit) -> string -> int -> bool ->
+  ?write_to_log:(string -> unit) -> string -> int ->
    (Stunnel.t -> 'b) -> 'b
 
 (** Adds a reusable stunnel to the cache *)
 val add : Stunnel.t -> unit
 
 (** Given a host and port call a function with a cached stunnel, or return None. *)
-val with_remove : string -> int -> bool -> (Stunnel.t -> 'b) -> 'b option
+val with_remove : try_all:bool -> string -> int -> (Stunnel.t -> 'b) -> 'b option
 
 (** Empty the cache of all stunnels *)
 val flush : unit -> unit


### PR DESCRIPTION
Previously we exposed cert verification with the `verify_cert` parameter to `Stunnel.with_connect`. This was never actually used by the Citrix Hypervisor, so associated code wasn't being properly maintained. 

Here we update that code which modifies the stunnel client config, and expose cert verification via `Stunnel.set_verify_tls_certs` instead; this way we avoid having to endow each call to `with_connect` with a `verify_cert` flag.

This PR breaks xapi, and which is fixed in this PR: https://github.com/xapi-project/xen-api/pull/4247