### PR TITLE
maintenance: fix stunnel deps

### DIFF
--- a/stunnel.opam
+++ b/stunnel.opam
@@ -10,8 +10,12 @@ available: [ os = "linux" ]
 depends: [
   "ocaml"
   "dune" {build}
+  "astring"
   "forkexec"
   "safe-resources"
+  "uuidm"
+  "xapi-idl"
+  "xapi-inventory"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
   "xapi-stdext-unix"

--- a/stunnel/dune
+++ b/stunnel/dune
@@ -5,13 +5,11 @@
   (flags (:standard -w -37))
   (libraries astring
              forkexec
-             threads
-             fmt
-             ptime
-             logs.fmt
              safe-resources
+             uuidm
+             xapi-idl
+             xapi-inventory
              xapi-stdext-pervasives
              xapi-stdext-threads
-             xapi-stdext-unix
-             xapi-idl)
+             xapi-stdext-unix)
 )


### PR DESCRIPTION
Place (implicit_transitive_deps false) in dune-project to figure out
which dependencies are incorrect