### PR TITLE
CP-35584: remove unused parameter to enable per-connection tls verification

### DIFF
--- a/http-svr/xmlrpc_client.mli
+++ b/http-svr/xmlrpc_client.mli
@@ -27,7 +27,6 @@ module SSL : sig
   (** [make] is used to create a type [t] *)
   val make : ?use_fork_exec_helper:bool ->
     ?use_stunnel_cache:bool ->
-    ?verify_cert:bool ->
     ?task_id:string -> unit -> t
 end
 


### PR DESCRIPTION
This parameter was used exclusively by xapi to establish connections to WLB servers.

The parameter controlling these kinds of connections is being deprecated and the paramter in its usage remove to make it compatible with this change.

I'm drafting this until the xen-api change is ready.