### PR TITLE
REQ-403 ensure Pool.wlb_verify_cert flag still works

### DIFF
--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -155,7 +155,7 @@ let assert_dest_is_ok host =
 
 (** Returns an stunnel, either from the persistent cache or a fresh one which
     has been checked out and guaranteed to work. *)
-let with_reusable_stunnel ?use_fork_exec_helper ?write_to_log host port f =
+let with_reusable_stunnel ?use_fork_exec_helper ?write_to_log ?verify_cert host port f =
   (* 1. First check if there is a suitable stunnel in the cache. *)
   let rec loop () =
     match Stunnel_cache.with_remove ~try_all:false host port @@ fun x ->
@@ -211,16 +211,18 @@ module SSL = struct
   type t = {
     use_fork_exec_helper: bool;
     use_stunnel_cache: bool;
+    verify_cert: bool option;
     task_id: string option
   }
-  let make ?(use_fork_exec_helper=true) ?(use_stunnel_cache=false) ?task_id () = {
+  let make ?(use_fork_exec_helper=true) ?(use_stunnel_cache=false) ?(verify_cert) ?task_id () = {
     use_fork_exec_helper = use_fork_exec_helper;
     use_stunnel_cache = use_stunnel_cache;
+    verify_cert = verify_cert;
     task_id = task_id
   }
   let to_string (x: t) =
-    Printf.sprintf "{ use_fork_exec_helper = %b; use_stunnel_cache = %b; task_id = %s }"
-      x.use_fork_exec_helper x.use_stunnel_cache
+    Printf.sprintf "{ use_fork_exec_helper = %b; use_stunnel_cache = %b; verify_cert = %s; task_id = %s }"
+      x.use_fork_exec_helper x.use_stunnel_cache (Option.fold ~none:"None" ~some:(fun x -> string_of_bool x) x.verify_cert)
       (Option.fold ~none:"None" ~some:(fun x -> "Some " ^ x) x.task_id)
 end
 
@@ -262,10 +264,11 @@ let with_transport transport f =
   | SSL ({
       SSL.use_fork_exec_helper = use_fork_exec_helper;
       use_stunnel_cache = use_stunnel_cache;
+      verify_cert = verify_cert;
       task_id = task_id}, host, port) ->
     let st_proc' f =
       if use_stunnel_cache
-      then with_reusable_stunnel ~use_fork_exec_helper ~write_to_log host port f
+      then with_reusable_stunnel ~use_fork_exec_helper ~write_to_log ?verify_cert host port f
       else
         let unique_id = get_new_stunnel_id () in
         Stunnel.with_connect ~use_fork_exec_helper ~write_to_log ~unique_id ~extended_diagnosis:true host port f in

--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -271,7 +271,7 @@ let with_transport transport f =
       then with_reusable_stunnel ~use_fork_exec_helper ~write_to_log ?verify_cert host port f
       else
         let unique_id = get_new_stunnel_id () in
-        Stunnel.with_connect ~use_fork_exec_helper ~write_to_log ~unique_id ~extended_diagnosis:true host port f in
+        Stunnel.with_connect ?verify_cert ~use_fork_exec_helper ~write_to_log ~unique_id ~extended_diagnosis:true host port f in
     st_proc' @@ fun st_proc ->
     let s = st_proc.Stunnel.fd in
     let s_pid = Stunnel.getpid st_proc.Stunnel.pid in

--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -158,7 +158,7 @@ let assert_dest_is_ok host =
 let with_reusable_stunnel ?use_fork_exec_helper ?write_to_log ?verify_cert host port f =
   (* 1. First check if there is a suitable stunnel in the cache. *)
   let rec loop () =
-    match Stunnel_cache.with_remove ~try_all:false host port @@ fun x ->
+    match Stunnel_cache.with_remove ?verify_cert ~try_all:false host port @@ fun x ->
       if check_reusable x.Stunnel.fd (Stunnel.getpid x.Stunnel.pid)
       then Ok (f x)
       else begin
@@ -185,7 +185,7 @@ let with_reusable_stunnel ?use_fork_exec_helper ?write_to_log ?verify_cert host 
         incr attempt_number;
         try
           let unique_id = get_new_stunnel_id () in
-          Stunnel.with_connect ~unique_id ?use_fork_exec_helper ?write_to_log host port @@ fun x ->
+          Stunnel.with_connect ?verify_cert ~unique_id ?use_fork_exec_helper ?write_to_log host port @@ fun x ->
           if check_reusable x.Stunnel.fd (Stunnel.getpid x.Stunnel.pid)
           then result := Some (try Ok (f x) with e -> Backtrace.is_important e; Error e)
           else begin

--- a/http-svr/xmlrpc_client.mli
+++ b/http-svr/xmlrpc_client.mli
@@ -27,6 +27,7 @@ module SSL : sig
   (** [make] is used to create a type [t] *)
   val make : ?use_fork_exec_helper:bool ->
     ?use_stunnel_cache:bool ->
+    ?verify_cert:bool ->
     ?task_id:string -> unit -> t
 end
 

--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -272,13 +272,15 @@ let rec retry f = function
     deleted.  Instead, it is the caller's responsibility to delete it.  This
     allows the caller to use diagnose_failure below if stunnel fails.  *)
 let with_connect
+    ?(verify_cert=false)
     ?unique_id
     ?use_fork_exec_helper
     ?write_to_log
     ?(extended_diagnosis=false)
     host
     port f = 
-  let _verify_cert = !verify_tls_certs in
+  (* CP-35584 HACK *)
+  let _verify_cert = !verify_tls_certs || verify_cert in
   let _ = match write_to_log with
     | Some logger -> stunnel_logger := logger
     | None -> () in

--- a/stunnel/stunnel.mli
+++ b/stunnel/stunnel.mli
@@ -47,6 +47,7 @@ val get_verify_tls_certs : unit -> bool
     For server-side connections, use Xmlrpcclient.get_reusable_stunnel instead.
 *)
 val with_connect :
+  ?verify_cert:bool ->
   ?unique_id:int ->
   ?use_fork_exec_helper:bool ->
   ?write_to_log:(string -> unit) ->

--- a/stunnel/stunnel_cache.ml
+++ b/stunnel/stunnel_cache.ml
@@ -193,9 +193,10 @@ let _with_remove host port verified f =
 
 (* [try_all] means that if we can't find any stunnels to [host] in the expected
    verified mode, then we'll look in the unexpected mode as well. if neither are
-   found, only then will we return None *)
-let with_remove ~try_all host port f =
-  let verified = Stunnel.get_verify_tls_certs () in
+   found, only then will we return None. *)
+let with_remove ?(verify_cert=false) ~try_all host port f =
+  (* CP-35584 HACK *)
+  let verified = Stunnel.get_verify_tls_certs () || verify_cert in
   if not try_all then
     _with_remove host port verified f
   else
@@ -215,9 +216,9 @@ let flush () =
        info "Flushed!")
 
 
-let with_connect ?use_fork_exec_helper ?write_to_log host port f =
-  match with_remove ~try_all:false host port f with
+let with_connect ?(verify_cert=false) ?use_fork_exec_helper ?write_to_log host port f =
+  match with_remove ~verify_cert ~try_all:false host port f with
   | Some r -> r
   | None ->
     info "connect did not find cached stunnel for endpoint %s:%d" host port;
-    Stunnel.with_connect ?use_fork_exec_helper ?write_to_log host port f
+    Stunnel.with_connect ~verify_cert ?use_fork_exec_helper ?write_to_log host port f

--- a/stunnel/stunnel_cache.mli
+++ b/stunnel/stunnel_cache.mli
@@ -25,15 +25,17 @@
     a host and port. If there is a suitable stunnel in the cache then this 
     will be used, otherwise we make a fresh one. *)
 val with_connect :
+  ?verify_cert:bool ->
   ?use_fork_exec_helper:bool ->
-  ?write_to_log:(string -> unit) -> string -> int ->
+  ?write_to_log:(string -> unit) ->
+  string -> int ->
    (Stunnel.t -> 'b) -> 'b
 
 (** Adds a reusable stunnel to the cache *)
 val add : Stunnel.t -> unit
 
 (** Given a host and port call a function with a cached stunnel, or return None. *)
-val with_remove : try_all:bool -> string -> int -> (Stunnel.t -> 'b) -> 'b option
+val with_remove : ?verify_cert:bool -> try_all:bool -> string -> int -> (Stunnel.t -> 'b) -> 'b option
 
 (** Empty the cache of all stunnels *)
 val flush : unit -> unit


### PR DESCRIPTION
Our stunnel client library will now create a connection with verification if either the global flag is set, or we specifically ask for a particular connection to have verification (`let verified = Stunnel.get_verify_tls_certs () || verify_cert` - the former is the global flag and the latter is the local flag).

The only client which uses this `verify_cert` parameter is WLB, so this changes ensures that the Pool.wlb_verify_cert flag works as expected. See https://github.com/xapi-project/xen-api/pull/4278 - these PRs should be merged simultaneously