### PR TITLE
CP-36095 configure Stunnel SNI for client connections

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,4 @@
 profile=ocamlformat
-version=0.14.1
 indicate-multiline-delimiters=closing-on-separate-line
 if-then-else=fit-or-vertical
 dock-collection-brackets=true


### PR DESCRIPTION
Make stunnel clients verify the connection by asking for the server certificate. This only works with the public server certificate present on the client, which is currently not the default. Hence, this is behind a feature flag.

This is a draft because I still need to test it manually but want to give reviewers a heads up what is coming.