### PR TITLE
REQ-403 CP-33822 CP-35584 port to master

### DIFF
--- a/stunnel/stunnel.mli
+++ b/stunnel/stunnel.mli
@@ -18,6 +18,8 @@ exception Stunnel_verify_error of string
 
 val crl_path : string
 
+val verify_certificates_ctrl : string
+
 val timeoutidle : int option ref
 
 type pid =

--- a/stunnel/stunnel_cache.ml
+++ b/stunnel/stunnel_cache.ml
@@ -201,7 +201,8 @@ let flush () =
        info "Flushed!")
 
 
-let with_connect ?use_fork_exec_helper ?write_to_log host port verify_cert f =
+let with_connect ?use_fork_exec_helper ?write_to_log ?verify_cert host port f =
+  let verify_cert = Stunnel.must_verify_cert verify_cert in
   match with_remove host port verify_cert f with
   | Some r -> r
   | None ->

--- a/stunnel/stunnel_cache.mli
+++ b/stunnel/stunnel_cache.mli
@@ -26,8 +26,8 @@
     will be used, otherwise we make a fresh one. *)
 val with_connect :
   ?use_fork_exec_helper:bool ->
-  ?write_to_log:(string -> unit) -> string -> int -> bool ->
-   (Stunnel.t -> 'b) -> 'b
+  ?write_to_log:(string -> unit) ->
+  ?verify_cert:bool -> string -> int -> (Stunnel.t -> 'b) -> 'b
 
 (** Adds a reusable stunnel to the cache *)
 val add : Stunnel.t -> unit


### PR DESCRIPTION
Ideally we'd completely remove the `verify_cert` params, but we can't do that yet because we still depend on it to make WLB verification work independently of 'global REQ-403' TLS verification. The idea is that we'll revert the second commit (CP-35584, b8c6ce5) when that setting has been removed