### PR TITLE
CP-36100 for SNI xapi:pool use pool cert bundle

### DIFF
--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -24,7 +24,8 @@ exception Stunnel_binary_missing
 exception Stunnel_error of string
 exception Stunnel_verify_error of string
 
-let certificates_bundle_path = "/etc/stunnel/xapi-stunnel-ca-bundle.pem"
+let xapi_cert_bundle_path = "/etc/stunnel/xapi-stunnel-ca-bundle.pem"
+let pool_cert_bundle_path = "/etc/stunnel/xapi-pool-ca-bundle.pem"
 
 let crl_path = "/etc/stunnel/crls"
 let verify_certificates_ctrl = "/var/xapi/verify_certificates"
@@ -146,7 +147,7 @@ let config_file verify_cert extended_diagnosis host port =
       ; "# the cert of the server we connect to"
       ; "sni = pool"
       ; "verifyPeer=yes"
-      ; sprintf "CAfile=%s" certificates_bundle_path
+      ; sprintf "CAfile=%s" pool_cert_bundle_path
       ; (match Sys.readdir crl_path with
          | [| |] -> ""
          | _ -> sprintf "CRLpath=%s" crl_path


### PR DESCRIPTION
This concerns the configurations of clients that use Stunndel to connect
to a host. If the connection demands the connection to be verified, a
configuration using SNI 'pool' is used. This requires the client to know
the certificates of all hosts in the pool. The configuration expects to
find them in a single file that bundles them:

  /etc/stunnel/xapi-pool-ca-bundle.pem

The construction of this bundle is not the responsibility of this
library, however.

All this patch does is to make sure the correct bundle is used in the
case a verified connection is opened.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>