### PR TITLE
CP-36100-3 Thread Stunnel.config value for verification

### DIFF
--- a/gzip/gzip.ml
+++ b/gzip/gzip.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Gzip = Xapi_compression.Make(struct
+module Gzip = Xapi_compression.Make (struct
   (** Path to the gzip binary *)
   let executable = "/bin/gzip"
 end)

--- a/gzip/gzip.mli
+++ b/gzip/gzip.mli
@@ -12,13 +12,13 @@
  * GNU Lesser General Public License for more details.
  *)
 
+val compress : Unix.file_descr -> (Unix.file_descr -> unit) -> unit
 (** Runs a compression process which is fed from a pipe whose entrance is passed to 'f'
     and whose output is 'ofd' *)
-val compress: Unix.file_descr -> (Unix.file_descr -> unit) -> unit
 
+val decompress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
 (** Runs a decompression process which is fed from a pipe whose entrance is passed to 'f'
     and whose output is 'ofd' *)
-val decompress: Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
 
 (* Experimental decompressor which is fed from an fd and writes to a pipe *)
-val decompress_passive: Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
+val decompress_passive : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a

--- a/http-svr/buf_io.ml
+++ b/http-svr/buf_io.ml
@@ -13,13 +13,12 @@
  *)
 (* Buffered IO with timeouts *)
 
-type t = 
-  { 
-    fd : Unix.file_descr;
-    mutable buf : bytes;
-    mutable cur : int;
-    mutable max : int;
-  }
+type t = {
+    fd: Unix.file_descr
+  ; mutable buf: bytes
+  ; mutable cur: int
+  ; mutable max: int
+}
 
 type err =
   | (* Line input is > 1024 chars *)
@@ -27,20 +26,22 @@ type err =
   | (* EOF found, with no newline *)
       No_newline
 
-exception Timeout        (* Waited too long for data to appear *)
-exception Eof           
-exception Line of err    (* Raised by input_line only *)
+exception Timeout (* Waited too long for data to appear *)
+
+exception Eof
+
+exception Line of err (* Raised by input_line only *)
 
 let infinite_timeout = -1.
 
-
 let of_fd fd =
   (* Unix.set_nonblock fd;*)
-  { fd = fd;
-    (* FIXME -- this should be larger. Low for testing *)
-    buf = Bytes.create 1024;
-    cur = 0;
-    max = 0;
+  {
+    fd
+  ; (* FIXME -- this should be larger. Low for testing *)
+    buf= Bytes.create 1024
+  ; cur= 0
+  ; max= 0
   }
 
 let fd_of t = t.fd
@@ -51,112 +52,107 @@ let is_buffer_empty ic = ic.max - ic.cur <= 0
 
 (* Used as a temporary measure while converting from unbuffered to buffered
    I/O in the rest of the software. *)
-let assert_buffer_empty ic = 
+let assert_buffer_empty ic =
   if not (is_buffer_empty ic) then failwith "Buf_io buffer not empty"
 
 (* Shift the unprocessed data to the beginning of the buffer *)
 let shift ic =
-  if ic.cur=Bytes.length ic.buf  (* No unprocessed data!*)
-  then 
-    (ic.cur <- 0; ic.max <- 0;)
-  else begin
-    Bytes.blit ic.buf ic.cur ic.buf 0 (ic.max - ic.cur);
-    ic.max <- (ic.max - ic.cur);
-    ic.cur <- 0;
-  end
+  if ic.cur = Bytes.length ic.buf (* No unprocessed data!*) then (
+    ic.cur <- 0 ;
+    ic.max <- 0
+  ) else (
+    Bytes.blit ic.buf ic.cur ic.buf 0 (ic.max - ic.cur) ;
+    ic.max <- ic.max - ic.cur ;
+    ic.cur <- 0
+  )
 
 (* Check to see if we've got a line (ending in \n) in the buffer *)
 let got_line ic =
   try
     let n = Bytes.index_from ic.buf ic.cur '\n' in
-    if n>=ic.max then -1 else n
-  with
-    Not_found -> -1
+    if n >= ic.max then -1 else n
+  with Not_found -> -1
 
-let is_full ic =
-  ic.cur=0 && ic.max=Bytes.length ic.buf
+let is_full ic = ic.cur = 0 && ic.max = Bytes.length ic.buf
 
 (* Fill the buffer with everything that's ready to be read (up to the limit of the buffer *)
 let fill_buf ~buffered ic timeout =
   let buf_size = Bytes.length ic.buf in
-
   let fill_no_exc timeout len =
-    let l,_,_ = Unix.select [ic.fd] [] [] timeout in
-    if List.length l <> 0 
-    then 
+    let l, _, _ = Unix.select [ic.fd] [] [] timeout in
+    if List.length l <> 0 then (
       let n = Unix.read ic.fd ic.buf ic.max len in
-      ic.max <- n+ic.max;
-      if n=0 && len <> 0 then raise Eof;
-      n 
-    else
+      ic.max <- n + ic.max ;
+      if n = 0 && len <> 0 then raise Eof ;
+      n
+    ) else
       -1
   in
-
   (* If there's no space to read, shift *)
-  if ic.max=buf_size then shift ic;
+  if ic.max = buf_size then shift ic ;
   let space_left = buf_size - ic.max in
-
   (* Read byte one by one just do make sure we don't buffer too many chars *)
-  let n = fill_no_exc timeout (if buffered then space_left else min space_left 1) in
-
+  let n =
+    fill_no_exc timeout (if buffered then space_left else min space_left 1)
+  in
   (* Select returned nothing to read *)
-  if n= -1 then raise Timeout;
-
+  if n = -1 then raise Timeout ;
   if n = space_left then (
-    shift ic;
-    let tofillsz = if buffered then buf_size - ic.max else (min (buf_size - ic.max) 1) in
+    shift ic ;
+    let tofillsz =
+      if buffered then buf_size - ic.max else min (buf_size - ic.max) 1
+    in
     ignore (fill_no_exc 0.0 tofillsz)
   )
 
 (** Input one line terminated by \n *)
-let input_line ?(timeout=60.0) ic =
+let input_line ?(timeout = 60.0) ic =
   (* See if we've already input a line *)
   let n = got_line ic in
-
   let rec get_line () =
-    fill_buf ~buffered:false ic timeout;
+    fill_buf ~buffered:false ic timeout ;
     let n = got_line ic in
-    if n<0 && (not (is_full ic))
-    then get_line ()
-    else n
+    if n < 0 && not (is_full ic) then
+      get_line ()
+    else
+      n
   in
-
-  let n = if n<0 then get_line () else n in
-
+  let n = if n < 0 then get_line () else n in
   (* Still no \n? then either we've run out of data, or we've run out of space *)
-  if n<0 
-  then 
-    if ic.max=Bytes.length ic.buf 
-    then raise (Line Too_long) 
-    else (Printf.printf "got: '%s'\n" (Bytes.sub_string ic.buf ic.cur (ic.max - ic.cur)); raise (Line No_newline));
-
+  if n < 0 then
+    if ic.max = Bytes.length ic.buf then
+      raise (Line Too_long)
+    else (
+      Printf.printf "got: '%s'\n"
+        (Bytes.sub_string ic.buf ic.cur (ic.max - ic.cur)) ;
+      raise (Line No_newline)
+    ) ;
   (* Return the line, stripping the newline *)
-  let result = Bytes.sub ic.buf ic.cur (n-ic.cur) in 
-  ic.cur <- n + 1;
+  let result = Bytes.sub ic.buf ic.cur (n - ic.cur) in
+  ic.cur <- n + 1 ;
   result
 
 (** Input 'len' characters from ic and put them into the bytestring 'b' starting from 'from' *)
-let rec really_input ?(timeout=15.0) ic b from len =
-  if len=0 then () else begin 
-    if ic.max - ic.cur < len then fill_buf ~buffered:true ic timeout;
-    begin
-      let blitlen = if ic.max - ic.cur < len then ic.max - ic.cur else len in
-      Bytes.blit ic.buf ic.cur b from blitlen;
-      ic.cur <- ic.cur + blitlen;
-      really_input ~timeout ic b (from+blitlen) (len-blitlen) 
-    end
-  end
+let rec really_input ?(timeout = 15.0) ic b from len =
+  if len = 0 then
+    ()
+  else (
+    if ic.max - ic.cur < len then fill_buf ~buffered:true ic timeout ;
+    let blitlen = if ic.max - ic.cur < len then ic.max - ic.cur else len in
+    Bytes.blit ic.buf ic.cur b from blitlen ;
+    ic.cur <- ic.cur + blitlen ;
+    really_input ~timeout ic b (from + blitlen) (len - blitlen)
+  )
 
 let really_input_buf ?timeout ic len =
   let blksize = 2048 in
   let buf = Buffer.create blksize in
   let s = Bytes.create blksize in
   let left = ref len in
-  while !left > 0
-  do
+  while !left > 0 do
     let size = min blksize !left in
-    really_input ?timeout ic s 0 size;
-    Buffer.add_subbytes buf s 0 size;
+    really_input ?timeout ic s 0 size ;
+    Buffer.add_subbytes buf s 0 size ;
     left := !left - size
-  done;
+  done ;
   Buffer.contents buf

--- a/http-svr/buf_io.mli
+++ b/http-svr/buf_io.mli
@@ -24,11 +24,11 @@ val infinite_timeout : float
 
 (** {2 Input functions} *)
 
-(** Input one line terminated by \n *)
 val input_line : ?timeout:float -> t -> bytes
+(** Input one line terminated by \n *)
 
-(** Input 'len' characters from ic and put them into the string 'str' starting from 'from' *)
 val really_input : ?timeout:float -> t -> bytes -> int -> int -> unit
+(** Input 'len' characters from ic and put them into the string 'str' starting from 'from' *)
 
 val really_input_buf : ?timeout:float -> t -> int -> string
 
@@ -41,14 +41,15 @@ exception Eof
 
 (** Raised by input_line only *)
 type err =
-  | Too_long   (** Line input is > 1024 chars *)
-  | No_newline (** EOF found, with no newline *)
+  | Too_long  (** Line input is > 1024 chars *)
+  | No_newline  (** EOF found, with no newline *)
 
 exception Line of err
 
 (** {2 Internal functions} *)
 
 val is_buffer_empty : t -> bool
+
 val assert_buffer_empty : t -> unit
 
 (* val assert_buffer_empty : t -> unit

--- a/http-svr/http.ml
+++ b/http-svr/http.ml
@@ -17,174 +17,261 @@
 open Xapi_stdext_unix
 
 exception Http_parse_failure
+
 exception Unauthorised of string
+
 exception Forbidden
+
 exception Method_not_implemented
+
 exception Malformed_url of string
 
+module D = Debug.Make (struct let name = "http" end)
 
-module D = Debug.Make(struct let name = "http" end)
 open D
 
-let http_403_forbidden ?(version="1.1") () =
-  [ Printf.sprintf "HTTP/%s 403 Forbidden" version;
-    "Connection: close";
-    "Cache-Control: no-cache, no-store" ]
+let http_403_forbidden ?(version = "1.1") () =
+  [
+    Printf.sprintf "HTTP/%s 403 Forbidden" version
+  ; "Connection: close"
+  ; "Cache-Control: no-cache, no-store"
+  ]
 
-let http_200_ok ?(version="1.1") ?(keep_alive=true) () =
-  [ Printf.sprintf "HTTP/%s 200 OK" version;
-    "Connection: " ^ (if keep_alive then "keep-alive" else "close");
-    "Cache-Control: no-cache, no-store" ]
+let http_200_ok ?(version = "1.1") ?(keep_alive = true) () =
+  [
+    Printf.sprintf "HTTP/%s 200 OK" version
+  ; ("Connection: " ^ if keep_alive then "keep-alive" else "close")
+  ; "Cache-Control: no-cache, no-store"
+  ]
 
-let http_200_ok_with_content length ?(version="1.1") ?(keep_alive=true) () =
-  [ Printf.sprintf "HTTP/%s 200 OK" version;
-    "Connection: " ^ (if keep_alive then "keep-alive" else "close");
-    "Content-Length: "^(Int64.to_string length);
-    "Cache-Control: no-cache, no-store" ]
+let http_200_ok_with_content length ?(version = "1.1") ?(keep_alive = true) () =
+  [
+    Printf.sprintf "HTTP/%s 200 OK" version
+  ; ("Connection: " ^ if keep_alive then "keep-alive" else "close")
+  ; "Content-Length: " ^ Int64.to_string length
+  ; "Cache-Control: no-cache, no-store"
+  ]
 
-let http_404_missing ?(version="1.1") () =
-  [ Printf.sprintf "HTTP/%s 404 Not Found" version;
-    "Connection: close";
-    "Cache-Control: no-cache, no-store" ]
+let http_404_missing ?(version = "1.1") () =
+  [
+    Printf.sprintf "HTTP/%s 404 Not Found" version
+  ; "Connection: close"
+  ; "Cache-Control: no-cache, no-store"
+  ]
 
-let http_302_redirect ?(version="1.1") url =
-  [ Printf.sprintf "HTTP/%s 302 Found" version;
-    "Connection: close";
-    "Cache-Control: no-cache, no-store";
-    "Location: "^url ]
+let http_302_redirect ?(version = "1.1") url =
+  [
+    Printf.sprintf "HTTP/%s 302 Found" version
+  ; "Connection: close"
+  ; "Cache-Control: no-cache, no-store"
+  ; "Location: " ^ url
+  ]
 
-let http_400_badrequest ?(version="1.1") () =
-  [ Printf.sprintf "HTTP/%s 400 Bad Request" version;
-    "Connection: close";
-    "Cache-Control: no-cache, no-store" ]
+let http_400_badrequest ?(version = "1.1") () =
+  [
+    Printf.sprintf "HTTP/%s 400 Bad Request" version
+  ; "Connection: close"
+  ; "Cache-Control: no-cache, no-store"
+  ]
 
-let http_500_internal_server_error ?(version="1.0") () =
-  [ Printf.sprintf "HTTP/%s 500 Internal Server Error" version;
-    "Connection: close";
-    "Cache-Control: no-cache, no-store" ]
+let http_500_internal_server_error ?(version = "1.0") () =
+  [
+    Printf.sprintf "HTTP/%s 500 Internal Server Error" version
+  ; "Connection: close"
+  ; "Cache-Control: no-cache, no-store"
+  ]
 
-let http_501_method_not_implemented ?(version="1.0") () =
-  [ Printf.sprintf "HTTP/%s 501 Method Not Implemented" version;
-    "Connection: close";
-    "Cache-Control: no-cache, no-store" ]
+let http_501_method_not_implemented ?(version = "1.0") () =
+  [
+    Printf.sprintf "HTTP/%s 501 Method Not Implemented" version
+  ; "Connection: close"
+  ; "Cache-Control: no-cache, no-store"
+  ]
 
 module Hdr = struct
   let task_id = "task-id"
+
   let subtask_of = "subtask-of"
+
   let content_type = "content-type"
+
   let content_length = "content-length"
+
   let host = "host"
+
   let user_agent = "user-agent"
+
   let cookie = "cookie"
+
   let transfer_encoding = "transfer-encoding"
+
   let authorization = "authorization"
+
   let connection = "connection"
+
   let header_len = "hdr"
+
   let acrh = "access-control-request-headers"
+
   let cache_control = "cache-control"
+
   let content_disposition = "content-disposition"
+
   let accept = "accept"
 end
 
 let output_http fd headers =
   headers
-  |> List.map (fun x ->  Printf.sprintf "%s\r\n" x)
+  |> List.map (fun x -> Printf.sprintf "%s\r\n" x)
   |> String.concat ""
   |> Unixext.really_write_string fd
 
 let explode str = Astring.String.fold_right (fun c acc -> c :: acc) str []
-let implode chr_list = String.concat "" (List.map Astring.String.of_char chr_list)
+
+let implode chr_list =
+  String.concat "" (List.map Astring.String.of_char chr_list)
 
 let urldecode url =
   let chars = explode url in
   let rec fn ac = function
-    |'+'::tl -> fn (' ' :: ac) tl
-    |'%'::a::b::tl ->
-      let cs = try int_of_string (implode ['0';'x';a;b])
-        with _ -> raise (Malformed_url url) in
-      fn (Char.chr cs :: ac) tl
-    |x::tl -> fn (x :: ac) tl
-    |[] ->
-      implode (List.rev ac)
-  in fn [] chars
+    | '+' :: tl ->
+        fn (' ' :: ac) tl
+    | '%' :: a :: b :: tl ->
+        let cs =
+          try int_of_string (implode ['0'; 'x'; a; b])
+          with _ -> raise (Malformed_url url)
+        in
+        fn (Char.chr cs :: ac) tl
+    | x :: tl ->
+        fn (x :: ac) tl
+    | [] ->
+        implode (List.rev ac)
+  in
+  fn [] chars
 
 (* Encode @param suitably for appearing in a query parameter in a URL. *)
 let urlencode param =
   let chars = explode param in
   let rec fn = function
-    | x::tl ->
-      begin
+    | x :: tl ->
         let s =
-          if x = ' ' then "+"
+          if x = ' ' then
+            "+"
           else
             match x with
-            | 'A'..'Z'
-            | 'a'..'z'
-            | '0'..'9'
-            | '$' | '-' | '_' | '.' | '!'
-            | '*' | '\'' | '(' | ')' | ',' ->
-              Astring.String.of_char x
+            | 'A' .. 'Z'
+            | 'a' .. 'z'
+            | '0' .. '9'
+            | '$'
+            | '-'
+            | '_'
+            | '.'
+            | '!'
+            | '*'
+            | '\''
+            | '('
+            | ')'
+            | ',' ->
+                Astring.String.of_char x
             | _ ->
-              Printf.sprintf "%%%2x" (Char.code x)
+                Printf.sprintf "%%%2x" (Char.code x)
         in
         s ^ fn tl
-      end
     | [] ->
-      ""
-  in fn chars
+        ""
+  in
+  fn chars
 
 (** Parses strings of the form a=b&c=d into ["a", "b"; "c", "d"] *)
 let parse_keyvalpairs xs =
-  let kvpairs = List.map (Astring.String.cuts ~sep:"=") (Astring.String.cuts ~sep:"&" xs) in
-  List.map (function
-      | k :: vs -> ((urldecode k), urldecode (String.concat "=" vs))
-      | [] -> raise Http_parse_failure) kvpairs
+  let kvpairs =
+    List.map (Astring.String.cuts ~sep:"=") (Astring.String.cuts ~sep:"&" xs)
+  in
+  List.map
+    (function
+      | k :: vs ->
+          (urldecode k, urldecode (String.concat "=" vs))
+      | [] ->
+          raise Http_parse_failure)
+    kvpairs
 
-let parse_uri x = match Astring.String.cuts ~sep:"?" x with
-  | [ uri ] -> uri, []
-  | [ uri; params ] -> uri, parse_keyvalpairs params
-  | _ -> raise Http_parse_failure
+let parse_uri x =
+  match Astring.String.cuts ~sep:"?" x with
+  | [uri] ->
+      (uri, [])
+  | [uri; params] ->
+      (uri, parse_keyvalpairs params)
+  | _ ->
+      raise Http_parse_failure
 
-
-type authorization =
-  | Basic of string * string
-  | UnknownAuth of string
+type authorization = Basic of string * string | UnknownAuth of string
 [@@deriving rpc]
 
 let authorization_of_string x =
   let basic = "Basic " in
-  if Astring.String.is_prefix ~affix:basic x
-  then
-    let end_of_string s from =
-      String.sub s from ((String.length s)-from) in
+  if Astring.String.is_prefix ~affix:basic x then
+    let end_of_string s from = String.sub s from (String.length s - from) in
     match Base64.decode (end_of_string x (String.length basic)) with
-    | Result.Ok userpass -> (match Astring.String.cuts ~sep:":" userpass with
-      | [ username; password ] -> Basic(username, password)
-      | _ -> UnknownAuth x)
-    | Result.Error _ -> UnknownAuth x
-  else UnknownAuth x
+    | Result.Ok userpass -> (
+      match Astring.String.cuts ~sep:":" userpass with
+      | [username; password] ->
+          Basic (username, password)
+      | _ ->
+          UnknownAuth x
+    )
+    | Result.Error _ ->
+        UnknownAuth x
+  else
+    UnknownAuth x
 
 let string_of_authorization = function
-  | UnknownAuth x -> x
-  | Basic(username, password) -> "Basic " ^ (Base64.encode_string (username ^ ":" ^ password))
+  | UnknownAuth x ->
+      x
+  | Basic (username, password) ->
+      "Basic " ^ Base64.encode_string (username ^ ":" ^ password)
 
-type method_t = Get | Post | Put | Connect | Options | Unknown of string [@@deriving rpc]
+type method_t = Get | Post | Put | Connect | Options | Unknown of string
+[@@deriving rpc]
 
 let string_of_method_t = function
-  | Get -> "GET" | Post -> "POST" | Put -> "PUT" | Connect -> "CONNECT" | Options -> "OPTIONS" | Unknown x -> "Unknown " ^ x
+  | Get ->
+      "GET"
+  | Post ->
+      "POST"
+  | Put ->
+      "PUT"
+  | Connect ->
+      "CONNECT"
+  | Options ->
+      "OPTIONS"
+  | Unknown x ->
+      "Unknown " ^ x
+
 let method_t_of_string = function
-  | "GET" -> Get | "POST" -> Post | "PUT" -> Put | "CONNECT" -> Connect | "OPTIONS" -> Options | x -> Unknown x
+  | "GET" ->
+      Get
+  | "POST" ->
+      Post
+  | "PUT" ->
+      Put
+  | "CONNECT" ->
+      Connect
+  | "OPTIONS" ->
+      Options
+  | x ->
+      Unknown x
 
 module Scanner = struct
-  type t = {
-    marker: string;
-    mutable i: int;
-  }
-  let make x = { marker = x; i = 0 }
-  let input x c =
-    if c = x.marker.[x.i] then x.i <- x.i + 1 else x.i <- 0
+  type t = {marker: string; mutable i: int}
+
+  let make x = {marker= x; i= 0}
+
+  let input x c = if c = x.marker.[x.i] then x.i <- x.i + 1 else x.i <- 0
+
   let remaining x = String.length x.marker - x.i
+
   let matched x = x.i = String.length x.marker
+
   (* let to_string x = Printf.sprintf "%d" x.i *)
 end
 
@@ -197,68 +284,74 @@ let header_len_value_len = 5
 let read_up_to buf already_read marker fd =
   let marker = Scanner.make marker in
   let hl_marker = Scanner.make header_len_header in
-  let b = ref 0 in (* next free byte in [buf] *)
-
+  let b = ref 0 in
+  (* next free byte in [buf] *)
   let header_len = ref None in
   let header_len_value_at = ref None in
-  while not(Scanner.matched marker) do
-    let safe_to_read = match !header_len_value_at, !header_len with
-      | None, None -> Scanner.remaining marker
-      | Some x, None -> header_len_value_len - (!b - x)
-      | _, Some l -> l - !b in
-(*
+  while not (Scanner.matched marker) do
+    let safe_to_read =
+      match (!header_len_value_at, !header_len) with
+      | None, None ->
+          Scanner.remaining marker
+      | Some x, None ->
+          header_len_value_len - (!b - x)
+      | _, Some l ->
+          l - !b
+    in
+    (*
 		Printf.fprintf stderr "b = %d; safe_to_read = %d\n" !b safe_to_read;
 		flush stderr;
 *)
     let n =
-      if !b < already_read
-      then min safe_to_read (already_read - !b)
-      else Unix.read fd buf !b safe_to_read in
-    if n = 0 then raise End_of_file;
-(*
+      if !b < already_read then
+        min safe_to_read (already_read - !b)
+      else
+        Unix.read fd buf !b safe_to_read
+    in
+    if n = 0 then raise End_of_file ;
+    (*
 		Printf.fprintf stderr "  n = %d\n" n;
 		flush stderr;
 *)
     for j = 0 to n - 1 do
-(*
+      (*
 			Printf.fprintf stderr "b = %d; marker = %s; n = %d; j = %d\n" !b (Scanner.to_string marker) n j;
 			flush stderr;
 *)
-      Scanner.input marker (Bytes.get buf (!b + j));
-      if !header_len_value_at = None then begin
-        Scanner.input hl_marker (Bytes.get buf (!b + j));
-        if Scanner.matched hl_marker then begin
-          header_len_value_at := Some(!b + j + 1);
-(*
+      Scanner.input marker (Bytes.get buf (!b + j)) ;
+      if !header_len_value_at = None then (
+        Scanner.input hl_marker (Bytes.get buf (!b + j)) ;
+        if Scanner.matched hl_marker then
+          header_len_value_at := Some (!b + j + 1)
+        (*
 					Printf.fprintf stderr "header_len_value_at = %d\n" (!b + j + 1);
 					flush stderr
 *)
-        end
-      end
-    done;
-    b := !b + n;
-(*
+      )
+    done ;
+    b := !b + n ;
+    (*
 		Printf.fprintf stderr "b = %d\n" !b;
 		flush stderr;
 *)
     match !header_len_value_at with
     | Some x when x + header_len_value_len <= !b ->
-      (* We can now read the header len header *)
-      let hlv =
-        Bytes.sub_string buf x header_len_value_len
-      in
-(*
+        (* We can now read the header len header *)
+        let hlv = Bytes.sub_string buf x header_len_value_len in
+        (*
 				Printf.fprintf stderr "hlvn=[%s]" hlv;
 				flush stderr;
 *)
-      header_len := Some (int_of_string hlv);
-    | _ -> ()
-  done;
+        header_len := Some (int_of_string hlv)
+    | _ ->
+        ()
+  done ;
   !b
 
 let read_http_header buf fd = read_up_to buf 0 end_of_headers fd
 
-let smallest_request  = "GET / HTTP/1.0\r\n\r\n"
+let smallest_request = "GET / HTTP/1.0\r\n\r\n"
+
 (* let smallest_response = "HTTP/1.0 200 OK\r\n\r\n" *)
 let frame_header_length = String.length smallest_request
 
@@ -269,192 +362,253 @@ let make_frame_header headers =
   Printf.sprintf "FRAME %012d" (String.length headers)
 
 let read_frame_header buf =
-  let prefix =
-    Bytes.sub_string buf 0 frame_header_length
-  in
-  try
-    Scanf.sscanf prefix "FRAME %012d" (fun x -> Some x)
-  with _ -> None
+  let prefix = Bytes.sub_string buf 0 frame_header_length in
+  try Scanf.sscanf prefix "FRAME %012d" (fun x -> Some x) with _ -> None
 
 let read_http_request_header fd =
   let buf = Bytes.create 1024 in
-  Unixext.really_read fd buf 0 6;
+  Unixext.really_read fd buf 0 6 ;
   (* return PROXY header if it exists, and then read up to FRAME header length (which also may not exist) *)
-  let proxy = match Bytes.sub_string buf 0 6 with
-  | "PROXY " ->
-    let proxy_header_length = read_up_to buf 6 "\r\n" fd in
-    (* chop 'PROXY ' from the beginning, and '\r\n' from the end *)
-    let proxy = Bytes.sub_string buf 6 (proxy_header_length -6 -2) in
-    Unixext.really_read fd buf 0 frame_header_length;
-    Some proxy
-  | _ -> Unixext.really_read fd buf 6 (frame_header_length - 6); None
+  let proxy =
+    match Bytes.sub_string buf 0 6 with
+    | "PROXY " ->
+        let proxy_header_length = read_up_to buf 6 "\r\n" fd in
+        (* chop 'PROXY ' from the beginning, and '\r\n' from the end *)
+        let proxy = Bytes.sub_string buf 6 (proxy_header_length - 6 - 2) in
+        Unixext.really_read fd buf 0 frame_header_length ;
+        Some proxy
+    | _ ->
+        Unixext.really_read fd buf 6 (frame_header_length - 6) ;
+        None
   in
-  let (frame, headers_length) = match read_frame_header buf with
-  | None -> false, read_up_to buf frame_header_length end_of_headers fd
-  | Some length ->
-    Unixext.really_read fd buf 0 length ;
-    true, length
+  let frame, headers_length =
+    match read_frame_header buf with
+    | None ->
+        (false, read_up_to buf frame_header_length end_of_headers fd)
+    | Some length ->
+        Unixext.really_read fd buf 0 length ;
+        (true, length)
   in
-  frame, Bytes.sub_string buf 0 headers_length, proxy
+  (frame, Bytes.sub_string buf 0 headers_length, proxy)
 
 let read_http_response_header buf fd =
-  Unixext.really_read fd buf 0 frame_header_length;
+  Unixext.really_read fd buf 0 frame_header_length ;
   match read_frame_header buf with
-  | None -> read_up_to buf frame_header_length end_of_headers fd
-  | Some length -> Unixext.really_read fd buf 0 length; length
+  | None ->
+      read_up_to buf frame_header_length end_of_headers fd
+  | Some length ->
+      Unixext.really_read fd buf 0 length ;
+      length
 
 module Accept = struct
   (* Constraint: we can't have ty = None but subty <> None *)
   type t = {
-    ty: string option; (* None means '*' *)
-    subty: string option; (* None means '*' *)
-    q: int; (* range 0 - 1000 *)
-    (* We won't parse the more advanced stuff *)
+      ty: string option
+    ; (* None means '*' *)
+      subty: string option
+    ; (* None means '*' *)
+      q: int (* range 0 - 1000 *)
+             (* We won't parse the more advanced stuff *)
   }
 
   let string_of_t x =
-    Printf.sprintf "%s/%s;q=%.3f" (Option.value ~default:"*" x.ty) (Option.value ~default:"*" x.subty) (float_of_int x.q /. 1000.)
+    Printf.sprintf "%s/%s;q=%.3f"
+      (Option.value ~default:"*" x.ty)
+      (Option.value ~default:"*" x.subty)
+      (float_of_int x.q /. 1000.)
 
   let matches (ty, subty) = function
-    | { ty = Some ty'; subty = Some subty'; _ } -> ty' = ty && (subty' = subty)
-    | { ty = Some ty'; subty = None; _ } -> ty' = ty
-    | { ty = None;     subty = Some _; _ } -> assert false
-    | { ty = None;     subty = None; _ } -> true
+    | {ty= Some ty'; subty= Some subty'; _} ->
+        ty' = ty && subty' = subty
+    | {ty= Some ty'; subty= None; _} ->
+        ty' = ty
+    | {ty= None; subty= Some _; _} ->
+        assert false
+    | {ty= None; subty= None; _} ->
+        true
 
   (* compare [a] and [b] where both match some media type *)
-  let compare (a: t) (b: t) =
+  let compare (a : t) (b : t) =
     let c = compare a.q b.q in
-    if c <> 0
-    then -c (* q factor (user-preference) overrides all else *)
-    else match a.ty, b.ty with
-      | Some _, None -> 1
-      | None, Some _ -> -1
-      | _, _ ->
-        begin match a.subty, b.subty with
-          | Some _, None -> 1
-          | None, Some _ -> -1
-          | _, _ -> 0
-        end
+    if c <> 0 then
+      -c (* q factor (user-preference) overrides all else *)
+    else
+      match (a.ty, b.ty) with
+      | Some _, None ->
+          1
+      | None, Some _ ->
+          -1
+      | _, _ -> (
+        match (a.subty, b.subty) with
+        | Some _, None ->
+            1
+        | None, Some _ ->
+            -1
+        | _, _ ->
+            0
+      )
 
   let preferred_match media ts =
     match List.filter (matches media) ts with
-    | [] -> None
-    | xs -> Some (List.hd (List.sort compare xs))
+    | [] ->
+        None
+    | xs ->
+        Some (List.hd (List.sort compare xs))
 
   exception Parse_failure of string
-  let t_of_string x = match Astring.String.cuts ~sep:";" x with
-    | ty_subty :: params ->
-      let ty_of_string = function
-        | "*" -> None
-        | x -> Some x in
-      let ty, subty = match Astring.String.cuts ~sep:"/" ty_subty with
-        | [ ty; subty ] -> ty_of_string ty, ty_of_string subty
-        | _ -> raise (Parse_failure ty_subty) in
-      if ty = None && (subty <> None) then raise (Parse_failure x);
 
-      let params = List.map (fun x -> match Astring.String.cut ~sep:"=" x with
-          | Some (k, v) -> k, v
-          | _ -> raise (Parse_failure x)
-        ) params in
-      let q = if List.mem_assoc "q" params then int_of_float (1000. *. (float_of_string (List.assoc "q" params))) else 1000 in
-      { ty = ty; subty = subty; q = q }
-    | _ -> raise (Parse_failure x)
+  let t_of_string x =
+    match Astring.String.cuts ~sep:";" x with
+    | ty_subty :: params ->
+        let ty_of_string = function "*" -> None | x -> Some x in
+        let ty, subty =
+          match Astring.String.cuts ~sep:"/" ty_subty with
+          | [ty; subty] ->
+              (ty_of_string ty, ty_of_string subty)
+          | _ ->
+              raise (Parse_failure ty_subty)
+        in
+        if ty = None && subty <> None then raise (Parse_failure x) ;
+        let params =
+          List.map
+            (fun x ->
+              match Astring.String.cut ~sep:"=" x with
+              | Some (k, v) ->
+                  (k, v)
+              | _ ->
+                  raise (Parse_failure x))
+            params
+        in
+        let q =
+          if List.mem_assoc "q" params then
+            int_of_float (1000. *. float_of_string (List.assoc "q" params))
+          else
+            1000
+        in
+        {ty; subty; q}
+    | _ ->
+        raise (Parse_failure x)
 
   let ts_of_string x = List.map t_of_string (Astring.String.cuts ~sep:"," x)
 end
 
 module Request = struct
   type t = {
-    m: method_t;
-    uri: string;
-    query: (string*string) list;
-    version: string;
-    frame: bool;
-    transfer_encoding: string option;
-    accept: string option;
-    content_length: int64 option;
-    auth: authorization option;
-    cookie: (string * string) list;
-    task: string option;
-    subtask_of: string option;
-    content_type: string option;
-    host: string option;
-    user_agent: string option;
-    mutable close: bool;
-    additional_headers: (string*string) list;
-    body: string option;
-  } [@@deriving rpc]
-
-  let empty = {
-    m=Unknown "";
-    uri="";
-    query=[];
-    version="";
-    frame=false;
-    transfer_encoding=None;
-    accept=None;
-    content_length=None;
-    auth=None;
-    cookie=[];
-    task=None;
-    subtask_of=None;
-    content_type = None;
-    host = None;
-    user_agent = None;
-    close= true;
-    additional_headers=[];
-    body = None;
+      m: method_t
+    ; uri: string
+    ; query: (string * string) list
+    ; version: string
+    ; frame: bool
+    ; transfer_encoding: string option
+    ; accept: string option
+    ; content_length: int64 option
+    ; auth: authorization option
+    ; cookie: (string * string) list
+    ; task: string option
+    ; subtask_of: string option
+    ; content_type: string option
+    ; host: string option
+    ; user_agent: string option
+    ; mutable close: bool
+    ; additional_headers: (string * string) list
+    ; body: string option
   }
+  [@@deriving rpc]
 
-  let make ?(frame=false) ?(version="1.1") ?(keep_alive=true) ?accept ?cookie ?length ?auth ?subtask_of ?body ?(headers=[]) ?content_type ?host ?(query=[]) ~user_agent meth path =
-    { empty with
-      version = version;
-      frame = frame;
-      close = not keep_alive;
-      cookie = Option.value ~default:[] cookie;
-      subtask_of = subtask_of;
-      content_length = length;
-      auth = auth;
-      content_type = content_type;
-      host = host;
-      user_agent = Some user_agent;
-      m = meth;
-      uri = path;
-      additional_headers = headers;
-      body = body;
-      accept = accept;
-      query = query;
+  let empty =
+    {
+      m= Unknown ""
+    ; uri= ""
+    ; query= []
+    ; version= ""
+    ; frame= false
+    ; transfer_encoding= None
+    ; accept= None
+    ; content_length= None
+    ; auth= None
+    ; cookie= []
+    ; task= None
+    ; subtask_of= None
+    ; content_type= None
+    ; host= None
+    ; user_agent= None
+    ; close= true
+    ; additional_headers= []
+    ; body= None
+    }
+
+  let make ?(frame = false) ?(version = "1.1") ?(keep_alive = true) ?accept
+      ?cookie ?length ?auth ?subtask_of ?body ?(headers = []) ?content_type
+      ?host ?(query = []) ~user_agent meth path =
+    {
+      empty with
+      version
+    ; frame
+    ; close= not keep_alive
+    ; cookie= Option.value ~default:[] cookie
+    ; subtask_of
+    ; content_length= length
+    ; auth
+    ; content_type
+    ; host
+    ; user_agent= Some user_agent
+    ; m= meth
+    ; uri= path
+    ; additional_headers= headers
+    ; body
+    ; accept
+    ; query
     }
 
   let get_version x = x.version
 
-  let of_request_line x = match Astring.String.fields ~empty:false x with
-    | [ m; uri; version ] ->
-      (* Request-Line   = Method SP Request-URI SP HTTP-Version CRLF *)
-      let uri, query = parse_uri uri in
-      (* strip the "HTTP/" prefix from the version string *)
-      begin match Astring.String.cut ~sep:"/" version with
+  let of_request_line x =
+    match Astring.String.fields ~empty:false x with
+    | [m; uri; version] -> (
+        (* Request-Line   = Method SP Request-URI SP HTTP-Version CRLF *)
+        let uri, query = parse_uri uri in
+        (* strip the "HTTP/" prefix from the version string *)
+        match Astring.String.cut ~sep:"/" version with
         | Some (_, version) ->
-          { m = method_t_of_string m; frame = false; uri = uri; query = query;
-            content_length = None; transfer_encoding = None; accept = None;
-            version = version; cookie = []; auth = None; task = None;
-            subtask_of = None; content_type = None; host = None; user_agent = None;
-            close=false; additional_headers=[]; body = None }
+            {
+              m= method_t_of_string m
+            ; frame= false
+            ; uri
+            ; query
+            ; content_length= None
+            ; transfer_encoding= None
+            ; accept= None
+            ; version
+            ; cookie= []
+            ; auth= None
+            ; task= None
+            ; subtask_of= None
+            ; content_type= None
+            ; host= None
+            ; user_agent= None
+            ; close= false
+            ; additional_headers= []
+            ; body= None
+            }
         | None ->
-          error "Failed to parse: %s" x;
-          raise Http_parse_failure
-      end
-    | _ -> raise Http_parse_failure
+            error "Failed to parse: %s" x ;
+            raise Http_parse_failure
+      )
+    | _ ->
+        raise Http_parse_failure
 
   let to_string x =
-    let kvpairs x = String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) x) in
-    Printf.sprintf "{ frame = %b; method = %s; uri = %s; query = [ %s ]; content_length = [ %s ]; transfer encoding = %s; version = %s; cookie = [ %s ]; task = %s; subtask_of = %s; content-type = %s; host = %s; user_agent = %s }"
-      x.frame (string_of_method_t x.m) x.uri
-      (kvpairs x.query)
+    let kvpairs x =
+      String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) x)
+    in
+    Printf.sprintf
+      "{ frame = %b; method = %s; uri = %s; query = [ %s ]; content_length = [ \
+       %s ]; transfer encoding = %s; version = %s; cookie = [ %s ]; task = %s; \
+       subtask_of = %s; content-type = %s; host = %s; user_agent = %s }"
+      x.frame (string_of_method_t x.m) x.uri (kvpairs x.query)
       (Option.fold ~none:"" ~some:Int64.to_string x.content_length)
       (Option.value ~default:"" x.transfer_encoding)
-      x.version
-      "(value filtered)" (* cookies *)
+      x.version "(value filtered)" (* cookies *)
       (Option.value ~default:"" x.task)
       (Option.value ~default:"" x.subtask_of)
       (Option.value ~default:"" x.content_type)
@@ -462,111 +616,187 @@ module Request = struct
       (Option.value ~default:"" x.user_agent)
 
   let to_header_list x =
-    let kvpairs x = String.concat "&" (List.map (fun (k, v) -> urlencode k ^ "=" ^ (urlencode v)) x) in
-    let query = if x.query = [] then "" else "?" ^ (kvpairs x.query) in
-    let cookie = if x.cookie = [] then [] else [ Hdr.cookie ^": " ^ (kvpairs x.cookie) ] in
-    let transfer_encoding = Option.fold ~none:[] ~some:(fun x -> [ Hdr.transfer_encoding ^": " ^ x ]) x.transfer_encoding in
-    let accept = Option.fold ~none:[] ~some:(fun x -> [ Hdr.accept ^ ": " ^ x]) x.accept in
-    let content_length = Option.fold ~none:[] ~some:(fun x -> [ Printf.sprintf "%s: %Ld" Hdr.content_length x ]) x.content_length in
-    let auth = Option.fold ~none:[] ~some:(fun x -> [ Hdr.authorization ^": " ^ (string_of_authorization x) ]) x.auth in
-    let task = Option.fold ~none:[] ~some:(fun x -> [ Hdr.task_id ^ ": " ^ x ]) x.task in
-    let subtask_of = Option.fold ~none:[] ~some:(fun x -> [ Hdr.subtask_of ^ ": " ^ x ]) x.subtask_of in
-    let content_type = Option.fold ~none:[] ~some:(fun x -> [ Hdr.content_type ^": " ^ x ]) x.content_type in
-    let host = Option.fold ~none:[] ~some:(fun x -> [ Hdr.host^": " ^ x ]) x.host in
-    let user_agent = Option.fold ~none:[] ~some:(fun x -> [ Hdr.user_agent^": " ^ x ]) x.user_agent in
-    let close = [ Hdr.connection ^": " ^ (if x.close then "close" else "keep-alive") ] in
-    [ Printf.sprintf "%s %s%s HTTP/%s" (string_of_method_t x.m) x.uri query x.version ]
-    @ cookie @ transfer_encoding @ accept @ content_length @ auth @ task @ subtask_of @ content_type @ host @ user_agent @ close
-    @ (List.map (fun (k, v) -> k ^ ":" ^ v) x.additional_headers)
+    let kvpairs x =
+      String.concat "&"
+        (List.map (fun (k, v) -> urlencode k ^ "=" ^ urlencode v) x)
+    in
+    let query = if x.query = [] then "" else "?" ^ kvpairs x.query in
+    let cookie =
+      if x.cookie = [] then [] else [Hdr.cookie ^ ": " ^ kvpairs x.cookie]
+    in
+    let transfer_encoding =
+      Option.fold ~none:[]
+        ~some:(fun x -> [Hdr.transfer_encoding ^ ": " ^ x])
+        x.transfer_encoding
+    in
+    let accept =
+      Option.fold ~none:[] ~some:(fun x -> [Hdr.accept ^ ": " ^ x]) x.accept
+    in
+    let content_length =
+      Option.fold ~none:[]
+        ~some:(fun x -> [Printf.sprintf "%s: %Ld" Hdr.content_length x])
+        x.content_length
+    in
+    let auth =
+      Option.fold ~none:[]
+        ~some:(fun x -> [Hdr.authorization ^ ": " ^ string_of_authorization x])
+        x.auth
+    in
+    let task =
+      Option.fold ~none:[] ~some:(fun x -> [Hdr.task_id ^ ": " ^ x]) x.task
+    in
+    let subtask_of =
+      Option.fold ~none:[]
+        ~some:(fun x -> [Hdr.subtask_of ^ ": " ^ x])
+        x.subtask_of
+    in
+    let content_type =
+      Option.fold ~none:[]
+        ~some:(fun x -> [Hdr.content_type ^ ": " ^ x])
+        x.content_type
+    in
+    let host =
+      Option.fold ~none:[] ~some:(fun x -> [Hdr.host ^ ": " ^ x]) x.host
+    in
+    let user_agent =
+      Option.fold ~none:[]
+        ~some:(fun x -> [Hdr.user_agent ^ ": " ^ x])
+        x.user_agent
+    in
+    let close =
+      [(Hdr.connection ^ ": " ^ if x.close then "close" else "keep-alive")]
+    in
+    [
+      Printf.sprintf "%s %s%s HTTP/%s" (string_of_method_t x.m) x.uri query
+        x.version
+    ]
+    @ cookie
+    @ transfer_encoding
+    @ accept
+    @ content_length
+    @ auth
+    @ task
+    @ subtask_of
+    @ content_type
+    @ host
+    @ user_agent
+    @ close
+    @ List.map (fun (k, v) -> k ^ ":" ^ v) x.additional_headers
 
-  let to_headers_and_body (x: t) =
+  let to_headers_and_body (x : t) =
     (* If the body is given then compute a content length *)
-    let x = match x.body with
-      | None -> x
-      | Some b -> { x with content_length = Some (Int64.of_int (String.length b)) } in
+    let x =
+      match x.body with
+      | None ->
+          x
+      | Some b ->
+          {x with content_length= Some (Int64.of_int (String.length b))}
+    in
     let hl = to_header_list x @ [""] in
     let headers = String.concat "" (List.map (fun x -> x ^ "\r\n") hl) in
     let body = Option.value ~default:"" x.body in
-    headers, body
+    (headers, body)
 
-  let to_wire_string (x: t) =
+  let to_wire_string (x : t) =
     let headers, body = to_headers_and_body x in
     let frame_header = if x.frame then make_frame_header headers else "" in
     frame_header ^ headers ^ body
-
 end
 
 module Response = struct
   type t = {
-    version: string;
-    frame: bool;
-    code: string;
-    message: string;
-    content_length: int64 option;
-    task: string option;
-    additional_headers: (string*string) list;
-    body: string option;
+      version: string
+    ; frame: bool
+    ; code: string
+    ; message: string
+    ; content_length: int64 option
+    ; task: string option
+    ; additional_headers: (string * string) list
+    ; body: string option
   }
 
-  let _empty = {
-    version = "1.1";
-    frame = false;
-    code = "500";
-    message = "Empty response";
-    content_length = Some 0L;
-    task = None;
-    additional_headers = [];
-    body = None
-  }
+  let _empty =
+    {
+      version= "1.1"
+    ; frame= false
+    ; code= "500"
+    ; message= "Empty response"
+    ; content_length= Some 0L
+    ; task= None
+    ; additional_headers= []
+    ; body= None
+    }
 
   let to_string x =
-    let kvpairs x = String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) x) in
-    Printf.sprintf "{ frame = %b; version = %s; code = %s; message = %s; content_length = %s; task = %s; additional_headers = [ %s ] }"
+    let kvpairs x =
+      String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) x)
+    in
+    Printf.sprintf
+      "{ frame = %b; version = %s; code = %s; message = %s; content_length = \
+       %s; task = %s; additional_headers = [ %s ] }"
       x.frame x.version x.code x.message
-      (Option.fold ~none:"None" ~some:(fun x -> "Some " ^ (Int64.to_string x)) x.content_length)
+      (Option.fold ~none:"None"
+         ~some:(fun x -> "Some " ^ Int64.to_string x)
+         x.content_length)
       (Option.fold ~none:"None" ~some:(fun x -> "Some " ^ x) x.task)
       (kvpairs x.additional_headers)
 
-  let empty = {
-    version = "1.1";
-    frame = false;
-    code = "500";
-    message = "Unknown error message";
-    content_length = None;
-    task = None;
-    additional_headers = [];
-    body = None;
-  }
-  let make ?(frame=false) ?(version="1.1") ?length ?task ?(headers=[]) ?body code message = {
-    version = version;
-    frame = frame;
-    code = code;
-    message = message;
-    content_length = length;
-    task = task;
-    additional_headers = headers;
-    body = body
-  }
+  let empty =
+    {
+      version= "1.1"
+    ; frame= false
+    ; code= "500"
+    ; message= "Unknown error message"
+    ; content_length= None
+    ; task= None
+    ; additional_headers= []
+    ; body= None
+    }
 
-  let internal_error = { empty with code = "500"; message = "internal error"; content_length = Some 0L }
-  let to_header_list (x: t) =
+  let make ?(frame = false) ?(version = "1.1") ?length ?task ?(headers = [])
+      ?body code message =
+    {
+      version
+    ; frame
+    ; code
+    ; message
+    ; content_length= length
+    ; task
+    ; additional_headers= headers
+    ; body
+    }
+
+  let internal_error =
+    {empty with code= "500"; message= "internal error"; content_length= Some 0L}
+
+  let to_header_list (x : t) =
     let status = Printf.sprintf "HTTP/%s %s %s" x.version x.code x.message in
-    let content_length = Option.fold ~none:[] ~some:(fun x -> [ Printf.sprintf "%s: %Ld" Hdr.content_length x ]) x.content_length in
-    let task = Option.fold ~none:[] ~some:(fun x -> [ Hdr.task_id ^ ": " ^ x ]) x.task in
+    let content_length =
+      Option.fold ~none:[]
+        ~some:(fun x -> [Printf.sprintf "%s: %Ld" Hdr.content_length x])
+        x.content_length
+    in
+    let task =
+      Option.fold ~none:[] ~some:(fun x -> [Hdr.task_id ^ ": " ^ x]) x.task
+    in
     let headers = List.map (fun (k, v) -> k ^ ":" ^ v) x.additional_headers in
     status :: (content_length @ task @ headers)
 
-  let to_headers_and_body (x: t) =
+  let to_headers_and_body (x : t) =
     (* If the body is given then compute a content length *)
-    let x = match x.body with
-      | None -> x
-      | Some b -> { x with content_length = Some (Int64.of_int (String.length b)) } in
+    let x =
+      match x.body with
+      | None ->
+          x
+      | Some b ->
+          {x with content_length= Some (Int64.of_int (String.length b))}
+    in
     let hl = to_header_list x @ [""] in
     let headers = String.concat "" (List.map (fun x -> x ^ "\r\n") hl) in
     let body = Option.value ~default:"" x.body in
-    headers, body
+    (headers, body)
 
-  let to_wire_string (x: t) =
+  let to_wire_string (x : t) =
     let headers, body = to_headers_and_body x in
     let frame_header = if x.frame then make_frame_header headers else "" in
     frame_header ^ headers ^ body
@@ -577,104 +807,146 @@ end
 type 'a ll = End | Item of 'a * (unit -> 'a ll)
 
 let rec ll_iter f = function
-  | End -> ()
-  | Item (x, xs) -> f x; ll_iter f (xs ())
-
+  | End ->
+      ()
+  | Item (x, xs) ->
+      f x ;
+      ll_iter f (xs ())
 
 module Url = struct
   type http = {
-    host: string;
-    auth: authorization option;
-    port: int option;
-    ssl: bool;
+      host: string
+    ; auth: authorization option
+    ; port: int option
+    ; ssl: bool
   }
-  type file = {
-    path: string;
-  }
-  type scheme =
-    | Http of http
-    | File of file
-  type data = {
-    uri: string;
-    query_params: (string * string) list;
-  }
+
+  type file = {path: string}
+
+  type scheme = Http of http | File of file
+
+  type data = {uri: string; query_params: (string * string) list}
 
   type t = scheme * data
 
   let of_string url =
-    let sub_before c s =
-      String.sub s 0 (String.index s c)
-    in
+    let sub_before c s = String.sub s 0 (String.index s c) in
     let sub_after c s =
       let length = String.length s in
-      let start = (String.index s c) + 1 in
+      let start = String.index s c + 1 in
       String.sub s start (length - start)
     in
     let host x =
-      try x |> sub_after '[' |> sub_before ']' with Not_found ->   (* [<ipv6-literal>]... *)
-      try x |> sub_before ':' with Not_found ->                    (* <hostname|ipv4-literal>:... *)
-        x in                                                         (* <hostname|ipv4-literal> *)
+      try x |> sub_after '[' |> sub_before ']'
+      with Not_found -> (
+        try (* [<ipv6-literal>]... *)
+            x |> sub_before ':'
+        with Not_found -> (* <hostname|ipv4-literal>:... *)
+                          x
+      )
+    in
+    (* <hostname|ipv4-literal> *)
     let port x =
       let port_part =
-        try x |> sub_after ']' |> sub_after ':' with Not_found ->  (* ...]:port *)
-        try x |> sub_after ']' with Not_found ->                   (* ...] *)
-        try x |> sub_after ':' with Not_found ->                   (* ...:port *)
-          "" in                                                      (* no port *)
-      try Some (int_of_string port_part) with _ -> None in
-    let uname_password_host_port x = match Astring.String.cuts ~sep:"@" x with
-      | [ _ ] -> None, host x, port x
-      | [ uname_password; host_port ] ->
-        begin match Astring.String.cuts ~sep:":" uname_password with
-          | [ uname; password ] -> Some (Basic (uname, password)), host host_port, port host_port
-          | _ -> failwith (Printf.sprintf "Failed to parse authentication substring: %s" uname_password)
-        end
-      | _ -> failwith (Printf.sprintf "Failed to parse username password host and port: %s" x) in
-    let reconstruct_uri uri = "/" ^ (String.concat "/" uri) in
+        try x |> sub_after ']' |> sub_after ':'
+        with Not_found -> (
+          try (* ...]:port *)
+              x |> sub_after ']'
+          with Not_found -> (
+            try (* ...] *)
+                x |> sub_after ':'
+            with Not_found -> (* ...:port *)
+                              ""
+          )
+        )
+      in
+      (* no port *)
+      try Some (int_of_string port_part) with _ -> None
+    in
+    let uname_password_host_port x =
+      match Astring.String.cuts ~sep:"@" x with
+      | [_] ->
+          (None, host x, port x)
+      | [uname_password; host_port] -> (
+        match Astring.String.cuts ~sep:":" uname_password with
+        | [uname; password] ->
+            (Some (Basic (uname, password)), host host_port, port host_port)
+        | _ ->
+            failwith
+              (Printf.sprintf "Failed to parse authentication substring: %s"
+                 uname_password)
+      )
+      | _ ->
+          failwith
+            (Printf.sprintf
+               "Failed to parse username password host and port: %s" x)
+    in
+    let reconstruct_uri uri = "/" ^ String.concat "/" uri in
     let data_of_uri uri =
       let uri, params = parse_uri (reconstruct_uri uri) in
-      { uri = uri; query_params = params } in
+      {uri; query_params= params}
+    in
     let http_or_https ssl x =
       let uname_password, host, port = uname_password_host_port x in
-      let scheme = Http { host = host; port = port; auth = uname_password; ssl = ssl } in
-      scheme in
+      let scheme = Http {host; port; auth= uname_password; ssl} in
+      scheme
+    in
     match Astring.String.cuts ~sep:"/" url with
-    | "http:" :: "" :: x :: uri -> http_or_https false x, data_of_uri uri
-    | "https:" :: "" :: x :: uri -> http_or_https true x, data_of_uri uri
+    | "http:" :: "" :: x :: uri ->
+        (http_or_https false x, data_of_uri uri)
+    | "https:" :: "" :: x :: uri ->
+        (http_or_https true x, data_of_uri uri)
     | "file:" :: uri ->
-      let uri, params = parse_uri (reconstruct_uri uri) in
-      File { path = uri }, { uri = "/"; query_params = params }
-    | x :: _ -> failwith (Printf.sprintf "Unknown scheme %s" x)
-    | _ -> failwith (Printf.sprintf "Failed to parse URL: %s" url)
+        let uri, params = parse_uri (reconstruct_uri uri) in
+        (File {path= uri}, {uri= "/"; query_params= params})
+    | x :: _ ->
+        failwith (Printf.sprintf "Unknown scheme %s" x)
+    | _ ->
+        failwith (Printf.sprintf "Failed to parse URL: %s" url)
 
-  let data_to_string { uri = uri; query_params = params } =
-    let kvpairs x = String.concat "&" (List.map (fun (k, v) -> urlencode k ^ "=" ^ (urlencode v)) x) in
-    let params = if params = [] then "" else "?" ^ (kvpairs params) in
+  let data_to_string {uri; query_params= params} =
+    let kvpairs x =
+      String.concat "&"
+        (List.map (fun (k, v) -> urlencode k ^ "=" ^ urlencode v) x)
+    in
+    let params = if params = [] then "" else "?" ^ kvpairs params in
     uri ^ params
 
   (* Wrap a literal IPv6 address in square brackets; otherwise pass through *)
   let maybe_wrap_IPv6_literal addr =
-    if Unixext.domain_of_addr addr = Some Unix.PF_INET6 then "[" ^ addr ^ "]" else addr
+    if Unixext.domain_of_addr addr = Some Unix.PF_INET6 then
+      "[" ^ addr ^ "]"
+    else
+      addr
 
   let to_string = function
-    | File { path = path }, data -> Printf.sprintf "file:%s%s" path (data_to_string data) (* XXX *)
+    | File {path}, data ->
+        Printf.sprintf "file:%s%s" path (data_to_string data) (* XXX *)
     | Http h, data ->
-      let userpassat = match h.auth with
-        | Some (Basic (username, password)) -> Printf.sprintf "%s:%s@" username password
-        | _ -> "" in
-      let colonport = match h.port with
-        | Some x -> Printf.sprintf ":%d" x
-        | _ -> "" in
-      Printf.sprintf "http%s://%s%s%s%s" (if h.ssl then "s" else "")
-        userpassat (maybe_wrap_IPv6_literal h.host) colonport (data_to_string data)
+        let userpassat =
+          match h.auth with
+          | Some (Basic (username, password)) ->
+              Printf.sprintf "%s:%s@" username password
+          | _ ->
+              ""
+        in
+        let colonport =
+          match h.port with Some x -> Printf.sprintf ":%d" x | _ -> ""
+        in
+        Printf.sprintf "http%s://%s%s%s%s"
+          (if h.ssl then "s" else "")
+          userpassat
+          (maybe_wrap_IPv6_literal h.host)
+          colonport (data_to_string data)
 
   let get_uri (_scheme, data) = data.uri
-  let set_uri (scheme, data) u = (scheme, { data with uri = u })
+
+  let set_uri (scheme, data) u = (scheme, {data with uri= u})
 
   let get_query_params (_scheme, data) = data.query_params
 
   let get_query (_scheme, data) = data_to_string data
 
-  let auth_of (scheme, _) = match scheme with
-    | File _ -> None
-    | Http { auth = auth; _ } -> auth
+  let auth_of (scheme, _) =
+    match scheme with File _ -> None | Http {auth; _} -> auth
 end

--- a/http-svr/http.mli
+++ b/http-svr/http.mli
@@ -11,159 +11,213 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
+
 (** Recognised HTTP methods *)
 type method_t = Get | Post | Put | Connect | Options | Unknown of string
+
 val string_of_method_t : method_t -> string
+
 val method_t_of_string : string -> method_t
 
 (** Exception raised when parsing start line of request *)
 exception Http_parse_failure
+
 exception Unauthorised of string
+
 exception Method_not_implemented
+
 exception Forbidden
 
-type authorization = 
-  | Basic of string * string
-  | UnknownAuth of string
+type authorization = Basic of string * string | UnknownAuth of string
 
-val read_http_header: bytes -> Unix.file_descr -> int
-val make_frame_header: string -> string
+val read_http_header : bytes -> Unix.file_descr -> int
 
-val read_http_request_header: Unix.file_descr -> bool * string * string option
-val read_http_response_header: bytes -> Unix.file_descr -> int
+val make_frame_header : string -> string
+
+val read_http_request_header : Unix.file_descr -> bool * string * string option
+
+val read_http_response_header : bytes -> Unix.file_descr -> int
 
 module Accept : sig
   type t = {
-    (* None means '*' *)
-    ty: string option;
-    (* None means '*' *)
-    subty: string option;
-    q: int
+      (* None means '*' *)
+      ty: string option
+    ; (* None means '*' *)
+      subty: string option
+    ; q: int
   }
+
   exception Parse_failure of string
+
   val t_of_string : string -> t
+
   val ts_of_string : string -> t list
 
   val string_of_t : t -> string
 
-  val matches : (string * string) -> t -> bool
-  val preferred_match : (string * string) -> t list -> t option
-end
+  val matches : string * string -> t -> bool
 
+  val preferred_match : string * string -> t list -> t option
+end
 
 (** Parsed form of the HTTP request line plus cookie info *)
 module Request : sig
   type t = {
-    m: method_t;
-    uri: string;
-    query: (string*string) list;
-    version: string;
-    frame: bool;
-    transfer_encoding: string option;
-    accept: string option;
-    content_length: int64 option;
-    auth: authorization option;
-    cookie: (string * string) list;
-    task: string option;
-    subtask_of: string option;
-    content_type: string option;
-    host: string option;
-    user_agent: string option;
-    mutable close: bool;
-    additional_headers: (string*string) list;
-    body: string option;
+      m: method_t
+    ; uri: string
+    ; query: (string * string) list
+    ; version: string
+    ; frame: bool
+    ; transfer_encoding: string option
+    ; accept: string option
+    ; content_length: int64 option
+    ; auth: authorization option
+    ; cookie: (string * string) list
+    ; task: string option
+    ; subtask_of: string option
+    ; content_type: string option
+    ; host: string option
+    ; user_agent: string option
+    ; mutable close: bool
+    ; additional_headers: (string * string) list
+    ; body: string option
   }
 
   val rpc_of_t : t -> Rpc.t
+
   val t_of_rpc : Rpc.t -> t
 
-  val empty: t
+  val empty : t
 
+  val make :
+       ?frame:bool
+    -> ?version:string
+    -> ?keep_alive:bool
+    -> ?accept:string
+    -> ?cookie:(string * string) list
+    -> ?length:int64
+    -> ?auth:authorization
+    -> ?subtask_of:string
+    -> ?body:string
+    -> ?headers:(string * string) list
+    -> ?content_type:string
+    -> ?host:string
+    -> ?query:(string * string) list
+    -> user_agent:string
+    -> method_t
+    -> string
+    -> t
   (** [make] is the standard constructor for [t] *)
-  val make: ?frame:bool -> ?version:string -> ?keep_alive:bool -> ?accept:string -> ?cookie:(string*string) list -> ?length:int64 -> ?auth:authorization -> ?subtask_of:string -> ?body:string -> ?headers:(string*string) list -> ?content_type:string -> ?host:string -> ?query:((string * string) list) -> user_agent:string -> method_t -> string -> t
 
+  val get_version : t -> string
   (** [get_version t] returns the HTTP protocol version *)
-  val get_version: t -> string
 
+  val of_request_line : string -> t
   (** [of_request_line l] parses [l] of the form "METHOD HTTP/VERSION" and
       		returns the corresponding [t] *)
-  val of_request_line: string -> t
 
+  val to_string : t -> string
   (** [to_string t] returns a short string summarising [t] *)
-  val to_string: t -> string
 
+  val to_header_list : t -> string list
   (** [to_header_list t] returns the list of HTTP headers associated
       		with [t] *)
-  val to_header_list: t -> string list
 
+  val to_wire_string : t -> string
   (** [to_wire_string t] returns a string which could be sent to a server *)
-  val to_wire_string: t -> string
 end
 
 (** Parsed form of the HTTP response *)
 module Response : sig
   type t = {
-    version: string;
-    frame: bool;
-    code: string;
-    message: string;
-    content_length: int64 option;
-    task: string option;
-    additional_headers: (string*string) list;
-    body: string option
+      version: string
+    ; frame: bool
+    ; code: string
+    ; message: string
+    ; content_length: int64 option
+    ; task: string option
+    ; additional_headers: (string * string) list
+    ; body: string option
   }
 
-  val empty: t
+  val empty : t
 
+  val make :
+       ?frame:bool
+    -> ?version:string
+    -> ?length:int64
+    -> ?task:string
+    -> ?headers:(string * string) list
+    -> ?body:string
+    -> string
+    -> string
+    -> t
   (** Returns an instance of type t *)
-  val make: ?frame:bool -> ?version:string -> ?length:int64 -> ?task:string -> ?headers:(string*string) list -> ?body:string -> string -> string -> t
 
-  val internal_error: t
+  val internal_error : t
 
+  val to_string : t -> string
   (** [to_string t] returns a short string summarising [t] *)
-  val to_string: t -> string
 
+  val to_header_list : t -> string list
   (** [to_header_list t] returns the list of HTTP headers associated
       		with [t] *)
-  val to_header_list: t -> string list
 
+  val to_wire_string : t -> string
   (** [to_wire_string t] returns a string which could be sent to a client *)
-  val to_wire_string: t -> string
 end
 
 val authorization_of_string : string -> authorization
 
-val parse_uri : string -> string * ((string * string) list)
+val parse_uri : string -> string * (string * string) list
 
 val http_403_forbidden : ?version:string -> unit -> string list
+
 val http_200_ok : ?version:string -> ?keep_alive:bool -> unit -> string list
 
-val http_200_ok_with_content : int64 -> ?version:string -> ?keep_alive:bool -> unit -> string list
+val http_200_ok_with_content :
+  int64 -> ?version:string -> ?keep_alive:bool -> unit -> string list
+
 val http_302_redirect : ?version:string -> string -> string list
+
 val http_404_missing : ?version:string -> unit -> string list
+
 val http_400_badrequest : ?version:string -> unit -> string list
+
 val http_500_internal_server_error : ?version:string -> unit -> string list
+
 val http_501_method_not_implemented : ?version:string -> unit -> string list
 
 module Hdr : sig
-  
+  val task_id : string
   (** Header used for task id *)
-  val task_id: string
-  val subtask_of: string
-  val host: string
 
+  val subtask_of : string
+
+  val host : string
+
+  val user_agent : string
   (** Header used for User-Agent string *)
-  val user_agent: string
-  val content_type: string
-  val content_length: string
-  val cookie: string
-  val transfer_encoding: string
-  val authorization: string
-  val connection: string
+
+  val content_type : string
+
+  val content_length : string
+
+  val cookie : string
+
+  val transfer_encoding : string
+
+  val authorization : string
+
+  val connection : string
+
   val acrh : string
-  val cache_control: string
-  val content_disposition: string
-  val accept: string
+
+  val cache_control : string
+
+  val content_disposition : string
+
+  val accept : string
 end
 
 val output_http : Unix.file_descr -> string list -> unit
@@ -173,42 +227,39 @@ val parse_keyvalpairs : string -> (string * string) list
 val urlencode : string -> string
 
 type 'a ll = End | Item of 'a * (unit -> 'a ll)
+
 val ll_iter : ('a -> unit) -> 'a ll -> unit
 
 module Url : sig
   type http = {
-    host: string;
-    auth: authorization option;
-    port: int option;
-    ssl: bool;
+      host: string
+    ; auth: authorization option
+    ; port: int option
+    ; ssl: bool
   }
-  type file = {
-    path: string;
-  }
-  type scheme =
-    | Http of http
-    | File of file
-  type data = {
-    uri: string;
-    query_params: (string * string) list;
-  }
+
+  type file = {path: string}
+
+  type scheme = Http of http | File of file
+
+  type data = {uri: string; query_params: (string * string) list}
 
   type t = scheme * data
 
-  val of_string: string -> t
+  val of_string : string -> t
 
-  (** Wrap a literal IPv6 address in square brackets; otherwise pass through *)
   val maybe_wrap_IPv6_literal : string -> string
+  (** Wrap a literal IPv6 address in square brackets; otherwise pass through *)
 
-  val to_string: t -> string
+  val to_string : t -> string
 
-  val get_uri: t -> string
+  val get_uri : t -> string
 
-  val set_uri: t -> string -> t
+  val set_uri : t -> string -> t
 
-  val get_query_params: t -> (string * string) list
+  val get_query_params : t -> (string * string) list
 
-  val get_query: t -> string
+  val get_query : t -> string
 
-  val auth_of: t -> authorization option
+  val auth_of : t -> authorization option
 end

--- a/http-svr/http_client.ml
+++ b/http-svr/http_client.ml
@@ -13,7 +13,8 @@
  *)
 (* A very simple HTTP client *)
 
-module D = Debug.Make(struct let name="http" end)
+module D = Debug.Make (struct let name = "http" end)
+
 open D
 
 let lowercase = Astring.String.Ascii.lowercase
@@ -33,7 +34,8 @@ exception Http_error of string * string
 exception Parse_error of string
 
 let http_rpc_send_query fd request =
-  Xapi_stdext_unix.Unixext.really_write_string fd (Http.Request.to_wire_string request)
+  Xapi_stdext_unix.Unixext.really_write_string fd
+    (Http.Request.to_wire_string request)
 
 (* Internal exception thrown when reading a newline-terminated HTTP header when the
    connection is closed *)
@@ -42,140 +44,172 @@ exception Http_header_truncated of string
 (* Tediously read an HTTP header byte-by-byte. At some point we need to add buffering
    but we'll need to encapsulate our file descriptor into more of a channel-like object
    to make that work. *)
-let input_line_fd (fd: Unix.file_descr) =
+let input_line_fd (fd : Unix.file_descr) =
   let buf = Buffer.create 20 in
   let finished = ref false in
-  while not(!finished) do
+  while not !finished do
     let buffer = Bytes.make 1 ' ' in
     let read = Unix.read fd buffer 0 1 in
-    if read = 1 then begin
-      if (Bytes.to_string buffer) = "\n"
-      then finished := true
-      else Buffer.add_char buf (Bytes.get buffer 0)
-    end else begin
-      if Buffer.contents buf = ""
-      then finished := true
-      else raise (Http_header_truncated (Buffer.contents buf));
-    end
-  done;
+    if read = 1 then
+      if Bytes.to_string buffer = "\n" then
+        finished := true
+      else
+        Buffer.add_char buf (Bytes.get buffer 0)
+    else if Buffer.contents buf = "" then
+      finished := true
+    else
+      raise (Http_header_truncated (Buffer.contents buf))
+  done ;
   Buffer.contents buf
 
 let response_of_fd_exn_slow fd =
   let task_id = ref None in
   let content_length = ref None in
-
   (* Initial line has the response code on it *)
   let line = input_line_fd fd in
   let bits = Astring.String.fields ~empty:false line in
   (* We just ignore the initial "FRAME xxxxx" *)
-  let bits = if bits <> [] && List.hd bits = "FRAME" then List.tl bits else bits in
+  let bits =
+    if bits <> [] && List.hd bits = "FRAME" then List.tl bits else bits
+  in
   match bits with
   | http_version :: code :: rest ->
-    let version =
-      match Astring.String.cut ~sep:"/" http_version with
-      | Some (http, version) when Astring.String.is_suffix ~affix:"HTTP" http -> version
-      | _ ->
-        error "Failed to parse HTTP response status line [%s]" line;
-        raise (Parse_error (Printf.sprintf "Failed to parse %s" http_version))
-    in
-    let message = String.concat " " rest in
-    let end_of_headers = ref false in
-    let headers = ref [] in
-    while not !end_of_headers do
-      let line = input_line_fd fd in
-      (* NB input_line removes the final '\n'.
-         				   RFC1945 says to expect a '\r\n' (- '\n' = '\r') *)
-      match line with
-      | "" | "\r" -> end_of_headers := true
-      | x ->
-        let k, v = match Astring.String.cuts ~sep:":" x with
-          | [ k; v ] -> lowercase k, Astring.String.trim v
-          | _        -> "", "" in
-        if k = lowercase Http.Hdr.task_id then task_id := Some v
-        else if k = lowercase Http.Hdr.content_length then content_length := Some (Int64.of_string v)
-        else headers := (k, v) :: !headers
-    done;
-    {
-      Http.Response.version = version;
-      frame = false;
-      code = code;
-      message = message;
-      content_length = !content_length;
-      task = !task_id;
-      additional_headers = !headers;
-      body = None;
-    }
+      let version =
+        match Astring.String.cut ~sep:"/" http_version with
+        | Some (http, version) when Astring.String.is_suffix ~affix:"HTTP" http
+          ->
+            version
+        | _ ->
+            error "Failed to parse HTTP response status line [%s]" line ;
+            raise
+              (Parse_error (Printf.sprintf "Failed to parse %s" http_version))
+      in
+      let message = String.concat " " rest in
+      let end_of_headers = ref false in
+      let headers = ref [] in
+      while not !end_of_headers do
+        let line = input_line_fd fd in
+        (* NB input_line removes the final '\n'.
+           				   RFC1945 says to expect a '\r\n' (- '\n' = '\r') *)
+        match line with
+        | "" | "\r" ->
+            end_of_headers := true
+        | x ->
+            let k, v =
+              match Astring.String.cuts ~sep:":" x with
+              | [k; v] ->
+                  (lowercase k, Astring.String.trim v)
+              | _ ->
+                  ("", "")
+            in
+            if k = lowercase Http.Hdr.task_id then
+              task_id := Some v
+            else if k = lowercase Http.Hdr.content_length then
+              content_length := Some (Int64.of_string v)
+            else
+              headers := (k, v) :: !headers
+      done ;
+      {
+        Http.Response.version
+      ; frame= false
+      ; code
+      ; message
+      ; content_length= !content_length
+      ; task= !task_id
+      ; additional_headers= !headers
+      ; body= None
+      }
   | _ ->
-    error "Failed to parse HTTP response status line [%s]" line;
-    raise (Parse_error (Printf.sprintf "Expected initial header [%s]" line))
+      error "Failed to parse HTTP response status line [%s]" line ;
+      raise (Parse_error (Printf.sprintf "Expected initial header [%s]" line))
 
 (** [response_of_fd_exn fd] returns an Http.Response.t object, or throws an exception *)
 let response_of_fd_exn fd =
   let buf = Bytes.create 1024 in
   let b = Http.read_http_response_header buf fd in
   let buf = Bytes.sub_string buf 0 b in
-
   let open Http.Response in
-  snd(List.fold_left
-        (fun (status, res) header ->
-           if not status then begin
-             match Astring.String.cut ~sep:" " header with
-             | Some (http_version, rest)->
-               begin match Astring.String.cut ~sep:" " rest with
-                 | Some (code, message) ->
-                   begin match Astring.String.cut ~sep:"/" http_version with
-                     | Some ("HTTP", version) ->
-                       true, { res with version = version; code = code; message = message }
-                     | _ ->
-                       error "Failed to parse HTTP response status line [%s]" header;
-                       raise (Parse_error (Printf.sprintf "Failed to parse %s" http_version))
-                   end
-                 | None -> raise (Parse_error (Printf.sprintf "Failed to parse %s" rest))
-               end
-             | None -> raise (Parse_error (Printf.sprintf "Failed to parse %s" header))
-           end else begin
-             match Astring.String.cut ~sep:":" header with
-             | Some (k, v) ->
+  snd
+    (List.fold_left
+       (fun (status, res) header ->
+         if not status then
+           match Astring.String.cut ~sep:" " header with
+           | Some (http_version, rest) -> (
+             match Astring.String.cut ~sep:" " rest with
+             | Some (code, message) -> (
+               match Astring.String.cut ~sep:"/" http_version with
+               | Some ("HTTP", version) ->
+                   (true, {res with version; code; message})
+               | _ ->
+                   error "Failed to parse HTTP response status line [%s]" header ;
+                   raise
+                     (Parse_error
+                        (Printf.sprintf "Failed to parse %s" http_version))
+             )
+             | None ->
+                 raise (Parse_error (Printf.sprintf "Failed to parse %s" rest))
+           )
+           | None ->
+               raise (Parse_error (Printf.sprintf "Failed to parse %s" header))
+         else
+           match Astring.String.cut ~sep:":" header with
+           | Some (k, v) -> (
                let k = lowercase k in
                let v = Astring.String.trim v in
-               true, begin match k with
-                 | k when k = Http.Hdr.task_id -> { res with task = Some v }
-                 | k when k = Http.Hdr.content_length -> { res with content_length = Some (Int64.of_string v) }
-                 | k -> { res with additional_headers = (k, v) :: res.additional_headers }
-               end
-             | _ -> true, res (* end of headers? *)
-           end
-        ) (false, empty) (Astring.String.cuts ~sep:"\n" buf))
+               ( true
+               , match k with
+                 | k when k = Http.Hdr.task_id ->
+                     {res with task= Some v}
+                 | k when k = Http.Hdr.content_length ->
+                     {res with content_length= Some (Int64.of_string v)}
+                 | k ->
+                     {
+                       res with
+                       additional_headers= (k, v) :: res.additional_headers
+                     } )
+             )
+           | _ ->
+               (true, res) (* end of headers? *))
+       (false, empty)
+       (Astring.String.cuts ~sep:"\n" buf))
 
 (** [response_of_fd fd] returns an optional Http.Response.t record *)
-let response_of_fd ?(use_fastpath=false) fd =
+let response_of_fd ?(use_fastpath = false) fd =
   try
-    if use_fastpath
-    then Some(response_of_fd_exn fd)
-    else Some (response_of_fd_exn_slow fd)
+    if use_fastpath then
+      Some (response_of_fd_exn fd)
+    else
+      Some (response_of_fd_exn_slow fd)
   with
-  | Unix.Unix_error(_, _, _) as e -> raise e
-  | _ -> None
+  | Unix.Unix_error (_, _, _) as e ->
+      raise e
+  | _ ->
+      None
 
 (** See perftest/tests.ml *)
 let last_content_length = ref 0L
 
 let http_rpc_recv_response use_fastpath error_msg fd =
   match response_of_fd ~use_fastpath fd with
-  | None -> raise (Http_request_rejected error_msg)
-  | Some response ->
-    begin match response.Http.Response.code with
-      | ("401"|"403"|"500") as http_code -> raise (Http_error (http_code,error_msg))
-      | "200" ->
-        Option.iter (fun x -> last_content_length := x) response.Http.Response.content_length;
+  | None ->
+      raise (Http_request_rejected error_msg)
+  | Some response -> (
+    match response.Http.Response.code with
+    | ("401" | "403" | "500") as http_code ->
+        raise (Http_error (http_code, error_msg))
+    | "200" ->
+        Option.iter
+          (fun x -> last_content_length := x)
+          response.Http.Response.content_length ;
         response
-      | code -> raise (Http_request_rejected (Printf.sprintf "%s: %s" code error_msg))
-    end
+    | code ->
+        raise (Http_request_rejected (Printf.sprintf "%s: %s" code error_msg))
+  )
 
 (** [rpc request f] marshals the HTTP request represented by [request] and [body]
     and then parses the response. On success, [f] is called with an HTTP response record.
     On failure an exception is thrown. *)
-let rpc ?(use_fastpath=false) (fd: Unix.file_descr) request f =
+let rpc ?(use_fastpath = false) (fd : Unix.file_descr) request f =
   (*	Printf.printf "request = [%s]" (Http.Request.to_wire_string request);*)
-  http_rpc_send_query fd request;
+  http_rpc_send_query fd request ;
   f (http_rpc_recv_response use_fastpath (Http.Request.to_string request) fd) fd

--- a/http-svr/http_client.mli
+++ b/http-svr/http_client.mli
@@ -24,16 +24,22 @@ exception Http_request_rejected of string
 (** Thrown when we get a specific HTTP failure *)
 exception Http_error of string * string
 
+val response_of_fd :
+  ?use_fastpath:bool -> Unix.file_descr -> Http.Response.t option
 (** [response_of_fd fd] returns an HTTP response read from fd, or None *)
-val response_of_fd: ?use_fastpath:bool -> Unix.file_descr -> Http.Response.t option
 
+val response_of_fd_exn : Unix.file_descr -> Http.Response.t
 (** [response_of_fd fd] returns an HTTP response read from fd, or throws an exception *)
-val response_of_fd_exn: Unix.file_descr -> Http.Response.t
 
+val rpc :
+     ?use_fastpath:bool
+  -> Unix.file_descr
+  -> Http.Request.t
+  -> (Http.Response.t -> Unix.file_descr -> 'a)
+  -> 'a
 (** [rpc fd request body f] marshals the HTTP request represented by [request] and [body]
     through file descriptor [fd] and then applies the response to [f]. On failure an 
     exception is thrown. *)
-val rpc : ?use_fastpath:bool -> Unix.file_descr -> Http.Request.t -> (Http.Response.t -> Unix.file_descr -> 'a) -> 'a
 
+val last_content_length : int64 ref
 (** See perftest/tests.ml *)
-val last_content_length: int64 ref

--- a/http-svr/http_proxy.ml
+++ b/http-svr/http_proxy.ml
@@ -12,11 +12,12 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module D=Debug.Make(struct let name="http_proxy" end)
-open D
+module D = Debug.Make (struct let name = "http_proxy" end)
 
+open D
 open Xmlrpc_client
 open Xapi_stdext_threads.Threadext
+
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 let one request fromfd s =
@@ -24,28 +25,38 @@ let one request fromfd s =
   (* We can only proxy certain types of request properly *)
   match request.Http.Request.m with
   | Http.Get | Http.Post | Http.Put ->
-    (* Set Connection:close if it's not already set *)
-    request.Http.Request.close <- true;
-    (* Transmit request headers to master *)
-    Unixext.really_write_string s (Http.Request.to_wire_string request);
-    let limit = match request.Http.Request.m with
-      | Http.Get -> Some 0L
-      | _ -> request.Http.Request.content_length in
-    let (_: int64) = Unixext.copy_file ?limit fromfd s in
-    (* Receive response headers from master *)
-    let response = Option.value ~default:Http.Response.internal_error (Http_client.response_of_fd s) in
-    (* Transmit response headers to client *)
-    Unixext.really_write_string fromfd (Http.Response.to_wire_string response);
-    if response.Http.Response.code = "200" then begin
-      (* If there is a request payload then transmit *)
-      let (_: int64) = Unixext.copy_file ?limit:response.Http.Response.content_length s fromfd in
-      ()
-    end;
+      (* Set Connection:close if it's not already set *)
+      request.Http.Request.close <- true ;
+      (* Transmit request headers to master *)
+      Unixext.really_write_string s (Http.Request.to_wire_string request) ;
+      let limit =
+        match request.Http.Request.m with
+        | Http.Get ->
+            Some 0L
+        | _ ->
+            request.Http.Request.content_length
+      in
+      let (_ : int64) = Unixext.copy_file ?limit fromfd s in
+      (* Receive response headers from master *)
+      let response =
+        Option.value ~default:Http.Response.internal_error
+          (Http_client.response_of_fd s)
+      in
+      (* Transmit response headers to client *)
+      Unixext.really_write_string fromfd (Http.Response.to_wire_string response) ;
+      if response.Http.Response.code = "200" then
+        (* If there is a request payload then transmit *)
+        let (_ : int64) =
+          Unixext.copy_file ?limit:response.Http.Response.content_length s
+            fromfd
+        in
+        ()
   | m ->
-    error "Proxy doesn't support: %s" (Http.string_of_method_t m);
-    Http_svr.response_forbidden ~req:request fromfd
+      error "Proxy doesn't support: %s" (Http.string_of_method_t m) ;
+      Http_svr.response_forbidden ~req:request fromfd
 
 let server = ref None
+
 let m = Mutex.create ()
 
 let http_proxy src_ip src_port transport =
@@ -53,44 +64,45 @@ let http_proxy src_ip src_port transport =
     (* NB 'fromfd' is accepted within the server_io module and it expects us to close it *)
     finally
       (fun () ->
-         let bio = Buf_io.of_fd fromfd in
-         let request = Http_svr.request_of_bio bio in
-         Option.iter
-           (fun request ->
-              with_transport transport (one request fromfd)
-           ) request;
-      ) (fun () -> Unix.close fromfd)
+        let bio = Buf_io.of_fd fromfd in
+        let request = Http_svr.request_of_bio bio in
+        Option.iter
+          (fun request -> with_transport transport (one request fromfd))
+          request)
+      (fun () -> Unix.close fromfd)
   in
   try
     let addr = Unix.inet_addr_of_string src_ip in
     let sockaddr = Unix.ADDR_INET (addr, src_port) in
-    Mutex.execute m
-      (fun () ->
-         (* shutdown any server which currently exists *)
-         Option.iter (fun server -> server.Server_io.shutdown ()) !server;
-         (* Make sure we don't try to double-close the server *)
-         server := None;
-         let handler = { Server_io.name = "http_proxy"; body = tcp_connection } in
-         let sock = Unix.socket (Unix.domain_of_sockaddr sockaddr) Unix.SOCK_STREAM 0 in
-         begin
-           (* Make sure exceptions cause the socket to be closed *)
-           try
-             Unix.set_close_on_exec sock;
-             Unix.setsockopt sock Unix.SO_REUSEADDR true;
-             (match sockaddr with
-              | Unix.ADDR_INET _ -> Xapi_stdext_unix.Unixext.set_tcp_nodelay sock true
-              | _ -> ());
-             Unix.bind sock sockaddr;
-             Unix.listen sock 128
-           with e ->
-             debug "Caught exception in Http_svr.bind (closing socket): %s" (Printexc.to_string e);
-             Unix.close sock;
-             raise e
-         end;
-         let s = Server_io.server handler sock in
-         server := Some s
-      )
+    Mutex.execute m (fun () ->
+        (* shutdown any server which currently exists *)
+        Option.iter (fun server -> server.Server_io.shutdown ()) !server ;
+        (* Make sure we don't try to double-close the server *)
+        server := None ;
+        let handler = {Server_io.name= "http_proxy"; body= tcp_connection} in
+        let sock =
+          Unix.socket (Unix.domain_of_sockaddr sockaddr) Unix.SOCK_STREAM 0
+        in
+        ( try
+            (* Make sure exceptions cause the socket to be closed *)
+            Unix.set_close_on_exec sock ;
+            Unix.setsockopt sock Unix.SO_REUSEADDR true ;
+            ( match sockaddr with
+            | Unix.ADDR_INET _ ->
+                Xapi_stdext_unix.Unixext.set_tcp_nodelay sock true
+            | _ ->
+                ()
+            ) ;
+            Unix.bind sock sockaddr ; Unix.listen sock 128
+          with e ->
+            debug "Caught exception in Http_svr.bind (closing socket): %s"
+              (Printexc.to_string e) ;
+            Unix.close sock ;
+            raise e
+        ) ;
+        let s = Server_io.server handler sock in
+        server := Some s)
   with e ->
-    error "Caught exception setting up proxy from internal network: %s" (Printexc.to_string e);
+    error "Caught exception setting up proxy from internal network: %s"
+      (Printexc.to_string e) ;
     raise e
-

--- a/http-svr/http_proxy.mli
+++ b/http-svr/http_proxy.mli
@@ -12,10 +12,10 @@
  * GNU Lesser General Public License for more details.
  *)
 
+val one : Http.Request.t -> Unix.file_descr -> Unix.file_descr -> unit
 (** [one request input output] proxies the single HTTP request [request]
     from [input] to [output] *)
-val one: Http.Request.t -> Unix.file_descr -> Unix.file_descr -> unit
 
+val http_proxy : string -> int -> Xmlrpc_client.transport -> unit
 (** [http_proxy ip port transport] establishes an HTTP proxy on [ip]:[port]
     which forwards all requests via [transport] *)
-val http_proxy: string -> int -> Xmlrpc_client.transport -> unit

--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -30,14 +30,14 @@
  *)
 
 open Http
-
 module Mutex = Xapi_stdext_threads.Threadext.Mutex
 module Unixext = Xapi_stdext_unix.Unixext
 
 (* This resolves the lowercase deprecation for all compiler versions *)
 let lowercase = Astring.String.Ascii.lowercase
 
-module D = Debug.Make(struct let name="http" end)
+module D = Debug.Make (struct let name = "http" end)
+
 open D
 
 type uri_path = string
@@ -46,22 +46,18 @@ module Stats = struct
   (** Record of statistics per-handler *)
 
   type t = {
-    mutable n_requests: int; (** successful requests *)
-    mutable n_connections: int; (** closed connections *)
-    mutable n_framed: int; (** using the more efficient framed protocol *)
+      mutable n_requests: int  (** successful requests *)
+    ; mutable n_connections: int  (** closed connections *)
+    ; mutable n_framed: int  (** using the more efficient framed protocol *)
   }
-  let empty () = {
-    n_requests = 0;
-    n_connections = 0;
-    n_framed = 0;
-  }
-  let update (x: t) (m: Mutex.t) req =
-    Mutex.execute m
-      (fun () ->
-         x.n_requests <- x.n_requests + 1;
-         if req.Http.Request.close then x.n_connections <- x.n_connections + 1;
-         if req.Http.Request.frame then x.n_framed <- x.n_framed + 1;
-      )
+
+  let empty () = {n_requests= 0; n_connections= 0; n_framed= 0}
+
+  let update (x : t) (m : Mutex.t) req =
+    Mutex.execute m (fun () ->
+        x.n_requests <- x.n_requests + 1 ;
+        if req.Http.Request.close then x.n_connections <- x.n_connections + 1 ;
+        if req.Http.Request.frame then x.n_framed <- x.n_framed + 1)
 end
 
 (** Type of a function which can handle a Request.t *)
@@ -70,11 +66,10 @@ type 'a handler =
   | FdIO of (Http.Request.t -> Unix.file_descr -> 'a -> unit)
 
 (* try and do f (unit -> unit), ignore exceptions *)
-let best_effort f =
-  try f() with _ -> ()
+let best_effort f = try f () with _ -> ()
 
 let headers s headers =
-  output_http s headers;
+  output_http s headers ;
   output_http s [""]
 
 (* let response s hdrs length f =
@@ -86,156 +81,205 @@ let headers s headers =
 (* If http/1.0 was requested, return that, else return http/1.1 *)
 let get_return_version req =
   try
-    let (maj,min) = Scanf.sscanf (Request.get_version req) "%d.%d" (fun a b -> (a,b)) in
-    match (maj,min) with
-      (1,0) -> "1.0"
-    | _ -> "1.1"
+    let maj, min =
+      Scanf.sscanf (Request.get_version req) "%d.%d" (fun a b -> (a, b))
+    in
+    match (maj, min) with 1, 0 -> "1.0" | _ -> "1.1"
   with _ -> "1.1"
 
 let response_of_request req hdrs =
-  let connection = Http.Hdr.connection, if req.Request.close then "close" else "keep-alive" in
-  let cache = Http.Hdr.cache_control, "no-cache, no-store" in
-  Http.Response.make
-    ~version:(get_return_version req) ~frame:req.Http.Request.frame
-    ~headers:(connection :: cache :: hdrs) "200" "OK"
+  let connection =
+    (Http.Hdr.connection, if req.Request.close then "close" else "keep-alive")
+  in
+  let cache = (Http.Hdr.cache_control, "no-cache, no-store") in
+  Http.Response.make ~version:(get_return_version req)
+    ~frame:req.Http.Request.frame
+    ~headers:(connection :: cache :: hdrs)
+    "200" "OK"
 
-let response_fct req ?(hdrs=[]) s (response_length: int64) (write_response_to_fd_fn: Unix.file_descr -> unit) =
-  let res = { (response_of_request req hdrs) with Http.Response.content_length = Some response_length } in
-  Unixext.really_write_string s (Http.Response.to_wire_string res);
+let response_fct req ?(hdrs = []) s (response_length : int64)
+    (write_response_to_fd_fn : Unix.file_descr -> unit) =
+  let res =
+    {
+      (response_of_request req hdrs) with
+      Http.Response.content_length= Some response_length
+    }
+  in
+  Unixext.really_write_string s (Http.Response.to_wire_string res) ;
   write_response_to_fd_fn s
 
 let response_str req ?hdrs s body =
   let length = String.length body in
-  response_fct req ?hdrs s (Int64.of_int length) (fun s -> Unixext.really_write_string s body)
+  response_fct req ?hdrs s (Int64.of_int length) (fun s ->
+      Unixext.really_write_string s body)
 
-let response_missing ?(hdrs=[]) s body =
-  let connection = Http.Hdr.connection, "close" in
-  let cache = Http.Hdr.cache_control, "no-cache, no-store" in
-  let res = Http.Response.make
-      ~version:"1.1" ~headers:(connection :: cache :: hdrs)
-      ~body "404" "Not Found" in
+let response_missing ?(hdrs = []) s body =
+  let connection = (Http.Hdr.connection, "close") in
+  let cache = (Http.Hdr.cache_control, "no-cache, no-store") in
+  let res =
+    Http.Response.make ~version:"1.1"
+      ~headers:(connection :: cache :: hdrs)
+      ~body "404" "Not Found"
+  in
   Unixext.really_write_string s (Http.Response.to_wire_string res)
 
-let response_error_html ?(version="1.1") s code message hdrs body =
-  let connection = Http.Hdr.connection, "close" in
-  let cache = Http.Hdr.cache_control, "no-cache, no-store" in
-  let content_type = Http.Hdr.content_type, "text/html" in
-  let res = Http.Response.make
-      ~version ~headers:(content_type :: connection :: cache :: hdrs)
-      ~body code message in
+let response_error_html ?(version = "1.1") s code message hdrs body =
+  let connection = (Http.Hdr.connection, "close") in
+  let cache = (Http.Hdr.cache_control, "no-cache, no-store") in
+  let content_type = (Http.Hdr.content_type, "text/html") in
+  let res =
+    Http.Response.make ~version
+      ~headers:(content_type :: connection :: cache :: hdrs)
+      ~body code message
+  in
   Unixext.really_write_string s (Http.Response.to_wire_string res)
 
 let response_unauthorised ?req label s =
   let version = Option.map get_return_version req in
-  let body = "<html><body><h1>HTTP 401 unauthorised</h1>Please check your credentials and retry.</body></html>" in
-  let realm = "WWW-Authenticate", Printf.sprintf "Basic realm=\"%s\"" label in
-  response_error_html ?version s "401" "Unauthorised" [ realm ] body
+  let body =
+    "<html><body><h1>HTTP 401 unauthorised</h1>Please check your credentials \
+     and retry.</body></html>"
+  in
+  let realm = ("WWW-Authenticate", Printf.sprintf "Basic realm=\"%s\"" label) in
+  response_error_html ?version s "401" "Unauthorised" [realm] body
 
 let response_forbidden ?req s =
   let version = Option.map get_return_version req in
-  let body = "<html><body><h1>HTTP 403 forbidden</h1>Access to the requested resource is forbidden.</body></html>" in
+  let body =
+    "<html><body><h1>HTTP 403 forbidden</h1>Access to the requested resource \
+     is forbidden.</body></html>"
+  in
   response_error_html ?version s "403" "Forbidden" [] body
 
 let response_badrequest ?req s =
   let version = Option.map get_return_version req in
-  let body = "<html><body><h1>HTTP 400 bad request</h1>The HTTP request was malformed. Please correct and retry.</body></html>" in
+  let body =
+    "<html><body><h1>HTTP 400 bad request</h1>The HTTP request was malformed. \
+     Please correct and retry.</body></html>"
+  in
   response_error_html ?version s "400" "Bad Request" [] body
 
 let response_internal_error ?req ?extra s =
   let version = Option.map get_return_version req in
-  let extra = Option.fold ~none:"" ~some:(fun x -> "<h1> Additional information </h1>" ^ x) extra in
-  let body = "<html><body><h1>HTTP 500 internal server error</h1>An unexpected error occurred; please wait a while and try again. If the problem persists, please contact your support representative." ^ extra ^ "</body></html>" in
+  let extra =
+    Option.fold ~none:""
+      ~some:(fun x -> "<h1> Additional information </h1>" ^ x)
+      extra
+  in
+  let body =
+    "<html><body><h1>HTTP 500 internal server error</h1>An unexpected error \
+     occurred; please wait a while and try again. If the problem persists, \
+     please contact your support representative."
+    ^ extra
+    ^ "</body></html>"
+  in
   response_error_html ?version s "500" "Internal Error" [] body
 
 let response_method_not_implemented ?req s =
   let version = Option.map get_return_version req in
-  let extra = Option.fold ~none:"" ~some:(fun req ->
-      Printf.sprintf "<p>%s not supported.<br /></p>" (Http.string_of_method_t req.Http.Request.m)
-    ) req in
-  let body = "<html><body><h1>HTTP 501 Method Not Implemented</h1>" ^ extra ^ "</body></html>" in
+  let extra =
+    Option.fold ~none:""
+      ~some:(fun req ->
+        Printf.sprintf "<p>%s not supported.<br /></p>"
+          (Http.string_of_method_t req.Http.Request.m))
+      req
+  in
+  let body =
+    "<html><body><h1>HTTP 501 Method Not Implemented</h1>"
+    ^ extra
+    ^ "</body></html>"
+  in
   response_error_html ?version s "501" "Method not implemented" [] body
 
 let response_file ?mime_content_type s file =
   let size = (Unix.LargeFile.stat file).Unix.LargeFile.st_size in
-  let mime_header = Option.fold ~none:[] ~some:(fun ty -> [ Hdr.content_type, ty ]) mime_content_type in
-  let keep_alive = Http.Hdr.connection, "keep-alive" in
-  let res = Http.Response.make ~version:"1.1" ~headers:(keep_alive :: mime_header)
-      ~length:size "200" "OK" in
-  Unixext.with_file file [ Unix.O_RDONLY ] 0
-    (fun f ->
-       Unixext.really_write_string s (Http.Response.to_wire_string res);
-       let (_: int64) = Unixext.copy_file f s in
-       ()
-    )
+  let mime_header =
+    Option.fold ~none:[]
+      ~some:(fun ty -> [(Hdr.content_type, ty)])
+      mime_content_type
+  in
+  let keep_alive = (Http.Hdr.connection, "keep-alive") in
+  let res =
+    Http.Response.make ~version:"1.1"
+      ~headers:(keep_alive :: mime_header)
+      ~length:size "200" "OK"
+  in
+  Unixext.with_file file [Unix.O_RDONLY] 0 (fun f ->
+      Unixext.really_write_string s (Http.Response.to_wire_string res) ;
+      let (_ : int64) = Unixext.copy_file f s in
+      ())
 
 let respond_to_options req s =
   let access_control_allow_headers =
     try
       let acrh = List.assoc Hdr.acrh req.Request.additional_headers in
       Printf.sprintf "%s, X-Requested-With" acrh
-    with Not_found ->
-      "X-Requested-With"
+    with Not_found -> "X-Requested-With"
   in
-  response_fct req ~hdrs:[
-    "Access-Control-Allow-Origin", "*";
-    "Access-Control-Allow-Headers", access_control_allow_headers;
-    "Access-Control-Allow-Methods","PUT"] s 0L (fun _ -> ())
-
+  response_fct req
+    ~hdrs:
+      [
+        ("Access-Control-Allow-Origin", "*")
+      ; ("Access-Control-Allow-Headers", access_control_allow_headers)
+      ; ("Access-Control-Allow-Methods", "PUT")
+      ] s 0L (fun _ -> ())
 
 (** If no handler matches the request then call this callback *)
 let default_callback req bio _ =
-  response_forbidden (Buf_io.fd_of bio);
+  response_forbidden (Buf_io.fd_of bio) ;
   req.Request.close <- true
 
-
 module TE = struct
-  type 'a t = {
-    stats: Stats.t;
-    stats_m: Mutex.t;
-    handler: 'a handler
-  }
-  let empty () = {
-    stats = Stats.empty ();
-    stats_m = Mutex.create ();
-    handler = BufIO default_callback;
-  }
+  type 'a t = {stats: Stats.t; stats_m: Mutex.t; handler: 'a handler}
+
+  let empty () =
+    {
+      stats= Stats.empty ()
+    ; stats_m= Mutex.create ()
+    ; handler= BufIO default_callback
+    }
 end
 
+module MethodMap = Map.Make (struct
+  type t = Http.method_t
 
-module MethodMap = Map.Make(struct type t = Http.method_t let compare = compare end)
+  let compare = compare
+end)
 
 module Server = struct
   type 'a t = {
-    mutable handlers: 'a TE.t Radix_tree.t MethodMap.t;
-    mutable use_fastpath: bool;
-    default_context: 'a;
+      mutable handlers: 'a TE.t Radix_tree.t MethodMap.t
+    ; mutable use_fastpath: bool
+    ; default_context: 'a
   }
 
-  let empty default_context = {
-    handlers = MethodMap.empty;
-    use_fastpath = false;
-    default_context = default_context;
-  }
+  let empty default_context =
+    {handlers= MethodMap.empty; use_fastpath= false; default_context}
 
   let add_handler x ty uri handler =
     let existing =
-      if MethodMap.mem ty x.handlers
-      then MethodMap.find ty x.handlers
-      else Radix_tree.empty in
-    x.handlers <- MethodMap.add ty (Radix_tree.insert uri { (TE.empty ()) with TE.handler = handler } existing) x.handlers
+      if MethodMap.mem ty x.handlers then
+        MethodMap.find ty x.handlers
+      else
+        Radix_tree.empty
+    in
+    x.handlers <-
+      MethodMap.add ty
+        (Radix_tree.insert uri {(TE.empty ()) with TE.handler} existing)
+        x.handlers
 
   let find_stats x m uri =
-    if not (MethodMap.mem m x.handlers)
-    then None
+    if not (MethodMap.mem m x.handlers) then
+      None
     else
       let rt = MethodMap.find m x.handlers in
       Option.map (fun te -> te.TE.stats) (Radix_tree.longest_prefix uri rt)
 
   let all_stats x =
     let open Radix_tree in
-    MethodMap.fold (fun m rt acc ->
-        fold (fun k te acc -> (m, k, te.TE.stats) :: acc) acc rt
-      ) x.handlers []
+    MethodMap.fold
+      (fun m rt acc -> fold (fun k te acc -> (m, k, te.TE.stats) :: acc) acc rt)
+      x.handlers []
 
   let enable_fastpath x = x.use_fastpath <- true
 end
@@ -243,28 +287,35 @@ end
 let escape uri =
   (* from xapi-stdext-std xstringext *)
   let escaped ~rules string =
-    let aux h t = (
-      if List.mem_assoc h rules
-      then List.assoc h rules
-      else Astring.String.of_char h) :: t
+    let aux h t =
+      ( if List.mem_assoc h rules then
+          List.assoc h rules
+      else
+        Astring.String.of_char h
+      )
+      :: t
     in
     String.concat "" (Astring.String.fold_right aux string [])
   in
-  escaped ~rules:[ '<', "&lt;"
-                 ; '>', "&gt;"
-                 ; '\'', "&apos;"
-                 ; '"', "&quot;"
-                 ; '&', "&amp;"
-                 ] uri
+  escaped
+    ~rules:
+      [
+        ('<', "&lt;")
+      ; ('>', "&gt;")
+      ; ('\'', "&apos;")
+      ; ('"', "&quot;")
+      ; ('&', "&amp;")
+      ]
+    uri
 
 exception Too_many_headers
+
 exception Generic_error of string
 
 let request_of_bio_exn_slow ic =
   (* Try to keep the connection open for a while to prevent spurious End_of_file type
      	   problems under load *)
   let initial_timeout = 5. *. 60. in
-
   let content_length = ref (-1L) in
   let cookie = ref "" in
   let transfer_encoding = ref None in
@@ -275,19 +326,16 @@ let request_of_bio_exn_slow ic =
   let content_type = ref None in
   let host = ref None in
   let user_agent = ref None in
-
-  content_length := -1L;
-  cookie := "";
-
-  let req = Buf_io.input_line ~timeout:initial_timeout ic
-            |> Bytes.to_string
-            |> Request.of_request_line
+  content_length := -1L ;
+  cookie := "" ;
+  let req =
+    Buf_io.input_line ~timeout:initial_timeout ic
+    |> Bytes.to_string
+    |> Request.of_request_line
   in
-
   (* Default for HTTP/1.1 is persistent connections. Anything else closes *)
   (* the channel as soon as the request is processed *)
-  if req.Request.version <> "1.1" then req.Request.close <- true;
-
+  if req.Request.version <> "1.1" then req.Request.close <- true ;
   let rec read_rest_of_headers left =
     let cl_hdr = lowercase Http.Hdr.content_length in
     let cookie_hdr = lowercase Http.Hdr.cookie in
@@ -300,43 +348,73 @@ let request_of_bio_exn_slow ic =
     let content_type_hdr = lowercase Http.Hdr.content_type in
     let host_hdr = lowercase Http.Hdr.host in
     let user_agent_hdr = lowercase Http.Hdr.user_agent in
-    let r = Buf_io.input_line ~timeout:Buf_io.infinite_timeout ic |> Bytes.to_string in
+    let r =
+      Buf_io.input_line ~timeout:Buf_io.infinite_timeout ic |> Bytes.to_string
+    in
     match Astring.String.cut ~sep:":" r with
     | Some (k, v) ->
-      let k = lowercase k in
-      let v = String.trim v in
-      let absorbed = match k with
-        | k when k = cl_hdr -> content_length := Int64.of_string v; true
-        | k when k = cookie_hdr -> cookie := v; true
-        | k when k = transfer_encoding_hdr -> transfer_encoding := Some v; true
-        | k when k = accept_hdr -> accept := Some v; true
-        | k when k = auth_hdr -> auth := Some(authorization_of_string v); true
-        | k when k = task_hdr -> task := Some v; true
-        | k when k = subtask_of_hdr -> subtask_of := Some v; true
-        | k when k = content_type_hdr -> content_type := Some v; true
-        | k when k = host_hdr -> host := Some v; true
-        | k when k = user_agent_hdr -> user_agent := Some v; true
-        | k when k = connection_hdr ->
-          req.Request.close <- lowercase v = "close";
-          true
-        | _ -> false in
-      if not absorbed && left <= 0 then raise Too_many_headers;
-      if absorbed
-      then read_rest_of_headers (left - 1)
-      else (k, v) :: (read_rest_of_headers (left - 1))
-    | None -> [] in
+        let k = lowercase k in
+        let v = String.trim v in
+        let absorbed =
+          match k with
+          | k when k = cl_hdr ->
+              content_length := Int64.of_string v ;
+              true
+          | k when k = cookie_hdr ->
+              cookie := v ;
+              true
+          | k when k = transfer_encoding_hdr ->
+              transfer_encoding := Some v ;
+              true
+          | k when k = accept_hdr ->
+              accept := Some v ;
+              true
+          | k when k = auth_hdr ->
+              auth := Some (authorization_of_string v) ;
+              true
+          | k when k = task_hdr ->
+              task := Some v ;
+              true
+          | k when k = subtask_of_hdr ->
+              subtask_of := Some v ;
+              true
+          | k when k = content_type_hdr ->
+              content_type := Some v ;
+              true
+          | k when k = host_hdr ->
+              host := Some v ;
+              true
+          | k when k = user_agent_hdr ->
+              user_agent := Some v ;
+              true
+          | k when k = connection_hdr ->
+              req.Request.close <- lowercase v = "close" ;
+              true
+          | _ ->
+              false
+        in
+        if (not absorbed) && left <= 0 then raise Too_many_headers ;
+        if absorbed then
+          read_rest_of_headers (left - 1)
+        else
+          (k, v) :: read_rest_of_headers (left - 1)
+    | None ->
+        []
+  in
   let headers = read_rest_of_headers 242 in
-  { req with
-    Request.cookie = (Http.parse_keyvalpairs !cookie);
-    content_length = if !content_length = -1L then None else Some(!content_length);
-    auth = !auth;
-    task = !task;
-    subtask_of = !subtask_of;
-    content_type = !content_type;
-    host = !host;
-    user_agent = !user_agent;
-    additional_headers = headers;
-    accept = !accept;
+  {
+    req with
+    Request.cookie= Http.parse_keyvalpairs !cookie
+  ; content_length=
+      (if !content_length = -1L then None else Some !content_length)
+  ; auth= !auth
+  ; task= !task
+  ; subtask_of= !subtask_of
+  ; content_type= !content_type
+  ; host= !host
+  ; user_agent= !user_agent
+  ; additional_headers= headers
+  ; accept= !accept
   }
 
 (** [request_of_bio_exn ic] reads a single Http.req from [ic] and returns it. On error
@@ -345,187 +423,245 @@ let request_of_bio_exn_slow ic =
 let request_of_bio_exn bio =
   let fd = Buf_io.fd_of bio in
   let frame, headers, proxy = Http.read_http_request_header fd in
-  let additional_headers = proxy |> Option.fold ~none:[] ~some:(fun p -> [("STUNNEL_PROXY", p)]) in
+  let additional_headers =
+    proxy |> Option.fold ~none:[] ~some:(fun p -> [("STUNNEL_PROXY", p)])
+  in
   let open Http.Request in
-  Astring.String.cuts ~sep:"\n" headers |> List.fold_left
-        (fun (status, req) header ->
-           if not status then begin
-             match Astring.String.fields ~empty:false header with
-             | [ meth; uri; version ] ->
+  Astring.String.cuts ~sep:"\n" headers
+  |> List.fold_left
+       (fun (status, req) header ->
+         if not status then
+           match Astring.String.fields ~empty:false header with
+           | [meth; uri; version] ->
                (* Request-Line   = Method SP Request-URI SP HTTP-Version CRLF *)
                let uri, query = Http.parse_uri uri in
                let m = Http.method_t_of_string meth in
                let version =
                  let x = String.trim version in
                  let prefix = "HTTP/" in
-                 String.sub x (String.length prefix) (String.length x - (String.length prefix)) in
+                 String.sub x (String.length prefix)
+                   (String.length x - String.length prefix)
+               in
                let close = version = "1.0" in
-               true,
-               { req with m = m; uri = uri; query = query;
-                          version = version; close = close
-               }
-             | _ -> raise Http_parse_failure
-           end else begin
-             match Astring.String.cut ~sep:":" header with
-             | Some (k, v) ->
+               (true, {req with m; uri; query; version; close})
+           | _ ->
+               raise Http_parse_failure
+         else
+           match Astring.String.cut ~sep:":" header with
+           | Some (k, v) -> (
                let k = lowercase k in
                let v = String.trim v in
-               true, begin match k with
-                 | k when k = Http.Hdr.content_length -> { req with content_length = Some (Int64.of_string v) }
-                 | k when k = Http.Hdr.cookie -> { req with cookie = Http.parse_keyvalpairs v }
-                 | k when k = Http.Hdr.transfer_encoding -> { req with transfer_encoding = Some v }
-                 | k when k = Http.Hdr.accept -> { req with accept = Some v }
-                 | k when k = Http.Hdr.authorization -> { req with auth = Some(authorization_of_string v) }
-                 | k when k = Http.Hdr.task_id -> { req with task = Some v }
-                 | k when k = Http.Hdr.subtask_of -> { req with subtask_of = Some v }
-                 | k when k = Http.Hdr.content_type -> { req with content_type = Some v }
-                 | k when k = Http.Hdr.host -> { req with host = Some v }
-                 | k when k = Http.Hdr.user_agent -> { req with user_agent = Some v }
-                 | k when k = Http.Hdr.connection && lowercase v = "close" -> { req with close = true }
-                 | k when k = Http.Hdr.connection && lowercase v = "keep-alive" -> { req with close = false }
-                 | _ -> { req with additional_headers = (k, v) :: req.additional_headers }
-               end
-             | None -> true, req (* end of headers *)
-           end
-        ) (false, { empty with Http.Request.frame = frame ; additional_headers }) |> snd
+               ( true
+               , match k with
+                 | k when k = Http.Hdr.content_length ->
+                     {req with content_length= Some (Int64.of_string v)}
+                 | k when k = Http.Hdr.cookie ->
+                     {req with cookie= Http.parse_keyvalpairs v}
+                 | k when k = Http.Hdr.transfer_encoding ->
+                     {req with transfer_encoding= Some v}
+                 | k when k = Http.Hdr.accept ->
+                     {req with accept= Some v}
+                 | k when k = Http.Hdr.authorization ->
+                     {req with auth= Some (authorization_of_string v)}
+                 | k when k = Http.Hdr.task_id ->
+                     {req with task= Some v}
+                 | k when k = Http.Hdr.subtask_of ->
+                     {req with subtask_of= Some v}
+                 | k when k = Http.Hdr.content_type ->
+                     {req with content_type= Some v}
+                 | k when k = Http.Hdr.host ->
+                     {req with host= Some v}
+                 | k when k = Http.Hdr.user_agent ->
+                     {req with user_agent= Some v}
+                 | k when k = Http.Hdr.connection && lowercase v = "close" ->
+                     {req with close= true}
+                 | k when k = Http.Hdr.connection && lowercase v = "keep-alive"
+                   ->
+                     {req with close= false}
+                 | _ ->
+                     {
+                       req with
+                       additional_headers= (k, v) :: req.additional_headers
+                     } )
+             )
+           | None ->
+               (true, req) (* end of headers *))
+       (false, {empty with Http.Request.frame; additional_headers})
+  |> snd
 
 (** [request_of_bio ic] returns [Some req] read from [ic], or [None]. If [None] it will have
     	already sent back a suitable error code and response to the client. *)
-let request_of_bio ?(use_fastpath=false) ic =
+let request_of_bio ?(use_fastpath = false) ic =
   try
-    let r = (if use_fastpath then request_of_bio_exn else request_of_bio_exn_slow) ic in
-(*
+    let r =
+      (if use_fastpath then request_of_bio_exn else request_of_bio_exn_slow) ic
+    in
+    (*
 		Printf.fprintf stderr "Parsed [%s]\n" (Http.Request.to_wire_string r);
 		flush stderr;
 *)
     Some r
   with e ->
-    D.warn "%s (%s)" (Printexc.to_string e) __LOC__;
+    D.warn "%s (%s)" (Printexc.to_string e) __LOC__ ;
     best_effort (fun () ->
         let ss = Buf_io.fd_of ic in
         match e with
         (* Specific errors thrown during parsing *)
         | Http.Http_parse_failure ->
-          response_internal_error ss ~extra:"The HTTP headers could not be parsed.";
-          debug "Error parsing HTTP headers";
+            response_internal_error ss
+              ~extra:"The HTTP headers could not be parsed." ;
+            debug "Error parsing HTTP headers"
         | Too_many_headers ->
-          (* don't log anything, since it could fill the log *)
-          response_internal_error ss ~extra:"Too many HTTP headers were received.";
-        | Buf_io.Timeout -> ()
+            (* don't log anything, since it could fill the log *)
+            response_internal_error ss
+              ~extra:"Too many HTTP headers were received."
+        | Buf_io.Timeout ->
+            ()
         (* Idle connection closed. NB infinite timeout used when headers are being read *)
-        | Buf_io.Eof -> ()
+        | Buf_io.Eof ->
+            ()
         (* Connection terminated *)
         | Buf_io.Line _ ->
-          response_internal_error ss ~extra:"One of the header lines was too long.";
-          (* Generic errors thrown during parsing *)
-        | End_of_file -> ()
+            response_internal_error ss
+              ~extra:"One of the header lines was too long."
+        (* Generic errors thrown during parsing *)
+        | End_of_file ->
+            ()
         (* Premature termination of connection! *)
-        | Unix.Unix_error (a,b,c) ->
-          response_internal_error ss ~extra:(Printf.sprintf "Got UNIX error: %s %s %s" (Unix.error_message a) b c)
+        | Unix.Unix_error (a, b, c) ->
+            response_internal_error ss
+              ~extra:
+                (Printf.sprintf "Got UNIX error: %s %s %s"
+                   (Unix.error_message a) b c)
         | exc ->
-          response_internal_error ss ~extra:(escape (Printexc.to_string exc));
-          log_backtrace ();
-      );
+            response_internal_error ss ~extra:(escape (Printexc.to_string exc)) ;
+            log_backtrace ()) ;
     None
 
-let handle_one (x: 'a Server.t) ss context req =
+let handle_one (x : 'a Server.t) ss context req =
   let ic = Buf_io.of_fd ss in
   let finished = ref false in
   try
-    D.debug "Request %s" (Http.Request.to_string req);
-    let method_map = try MethodMap.find req.Request.m x.Server.handlers with Not_found -> raise Method_not_implemented in
+    D.debug "Request %s" (Http.Request.to_string req) ;
+    let method_map =
+      try MethodMap.find req.Request.m x.Server.handlers
+      with Not_found -> raise Method_not_implemented
+    in
     let empty = TE.empty () in
-    let te = Option.value ~default:empty (Radix_tree.longest_prefix req.Request.uri method_map) in
-    (match te.TE.handler with
-     | BufIO handlerfn -> handlerfn req ic context
-     | FdIO handlerfn ->
-       let fd = Buf_io.fd_of ic in
-       Buf_io.assert_buffer_empty ic;
-       handlerfn req fd context
-    );
-    finished := (req.Request.close);
-    Stats.update te.TE.stats te.TE.stats_m req;
+    let te =
+      Option.value ~default:empty
+        (Radix_tree.longest_prefix req.Request.uri method_map)
+    in
+    ( match te.TE.handler with
+    | BufIO handlerfn ->
+        handlerfn req ic context
+    | FdIO handlerfn ->
+        let fd = Buf_io.fd_of ic in
+        Buf_io.assert_buffer_empty ic ;
+        handlerfn req fd context
+    ) ;
+    finished := req.Request.close ;
+    Stats.update te.TE.stats te.TE.stats_m req ;
     !finished
   with e ->
-    finished := true;
-    best_effort (fun () -> match e with
+    finished := true ;
+    best_effort (fun () ->
+        match e with
         (* Specific errors thrown by handlers *)
         | Generic_error s ->
-          response_internal_error ~req ss ~extra:s
+            response_internal_error ~req ss ~extra:s
         | Http.Unauthorised realm ->
-          response_unauthorised ~req realm ss
+            response_unauthorised ~req realm ss
         | Http.Forbidden ->
-          response_forbidden ~req ss
+            response_forbidden ~req ss
         (* Generic errors thrown by handlers *)
         | Http.Method_not_implemented ->
-          response_method_not_implemented ~req ss
-        | End_of_file -> ()
+            response_method_not_implemented ~req ss
+        | End_of_file ->
+            ()
         (* Premature termination of connection! *)
-        | Unix.Unix_error (a,b,c) ->
-          response_internal_error ~req ss ~extra:(Printf.sprintf "Got UNIX error: %s %s %s" (Unix.error_message a) b c)
+        | Unix.Unix_error (a, b, c) ->
+            response_internal_error ~req ss
+              ~extra:
+                (Printf.sprintf "Got UNIX error: %s %s %s"
+                   (Unix.error_message a) b c)
         | exc ->
-          response_internal_error ~req ss ~extra:(escape (Printexc.to_string exc));
-          log_backtrace ()
-      );
+            response_internal_error ~req ss
+              ~extra:(escape (Printexc.to_string exc)) ;
+            log_backtrace ()) ;
     !finished
 
-let handle_connection (x: 'a Server.t) _ ss =
+let handle_connection (x : 'a Server.t) _ ss =
   let ic = Buf_io.of_fd ss in
   let finished = ref false in
-
   while not !finished do
     (* 1. we must successfully parse a request *)
     let req = request_of_bio ~use_fastpath:x.Server.use_fastpath ic in
-
     (* 2. now we attempt to process the request *)
-    finished := Option.fold ~none:true ~some:(handle_one x ss x.Server.default_context) req;
-  done;
+    finished :=
+      Option.fold ~none:true
+        ~some:(handle_one x ss x.Server.default_context)
+        req
+  done ;
   Unix.close ss
 
-let bind ?(listen_backlog=128) sockaddr name =
-  let domain = match sockaddr with
+let bind ?(listen_backlog = 128) sockaddr name =
+  let domain =
+    match sockaddr with
     | Unix.ADDR_UNIX path ->
-      debug "Establishing Unix domain server on path: %s" path;
-      Unix.PF_UNIX
-    | Unix.ADDR_INET(_,_) ->
-      debug "Establishing inet domain server";
-      Unix.domain_of_sockaddr sockaddr in
+        debug "Establishing Unix domain server on path: %s" path ;
+        Unix.PF_UNIX
+    | Unix.ADDR_INET (_, _) ->
+        debug "Establishing inet domain server" ;
+        Unix.domain_of_sockaddr sockaddr
+  in
   let sock = Unix.socket domain Unix.SOCK_STREAM 0 in
   (* Make sure exceptions cause the socket to be closed *)
   try
-    Unix.set_close_on_exec sock;
-    Unix.setsockopt sock Unix.SO_REUSEADDR true;
-    Unix.setsockopt sock Unix.SO_KEEPALIVE true;
-    (match sockaddr with Unix.ADDR_INET _ -> Unixext.set_tcp_nodelay sock true | _ -> ());
-    Unix.bind sock sockaddr;
-    Unix.listen sock listen_backlog;
-    sock, name
+    Unix.set_close_on_exec sock ;
+    Unix.setsockopt sock Unix.SO_REUSEADDR true ;
+    Unix.setsockopt sock Unix.SO_KEEPALIVE true ;
+    ( match sockaddr with
+    | Unix.ADDR_INET _ ->
+        Unixext.set_tcp_nodelay sock true
+    | _ ->
+        ()
+    ) ;
+    Unix.bind sock sockaddr ;
+    Unix.listen sock listen_backlog ;
+    (sock, name)
   with e ->
-    debug "Caught exception in Http_svr.bind (closing socket): %s" (Printexc.to_string e);
-    Unix.close sock;
+    debug "Caught exception in Http_svr.bind (closing socket): %s"
+      (Printexc.to_string e) ;
+    Unix.close sock ;
     raise e
 
-let bind_retry ?(listen_backlog=128) sockaddr =
-  let description = match sockaddr with
-    | Unix.ADDR_INET(ip, port) -> Printf.sprintf "INET %s:%d" (Unix.string_of_inet_addr ip) port
-    | Unix.ADDR_UNIX path -> Printf.sprintf "UNIX %s" path in
+let bind_retry ?(listen_backlog = 128) sockaddr =
+  let description =
+    match sockaddr with
+    | Unix.ADDR_INET (ip, port) ->
+        Printf.sprintf "INET %s:%d" (Unix.string_of_inet_addr ip) port
+    | Unix.ADDR_UNIX path ->
+        Printf.sprintf "UNIX %s" path
+  in
   (* Sometimes we see failures which we hope are transient. If this
      	   happens then we'll retry a couple of times before failing. *)
   let result = ref None in
   let start = Unix.gettimeofday () in
-  let timeout = 30.0 in (* 30s *)
-  while !result = None && (Unix.gettimeofday () -. start < timeout) do
-    try
-      result := Some (bind ~listen_backlog sockaddr description);
-    with Unix.Unix_error(code, _, _) ->
-      debug "While binding %s: %s" description (Unix.error_message code);
+  let timeout = 30.0 in
+  (* 30s *)
+  while !result = None && Unix.gettimeofday () -. start < timeout do
+    try result := Some (bind ~listen_backlog sockaddr description)
+    with Unix.Unix_error (code, _, _) ->
+      debug "While binding %s: %s" description (Unix.error_message code) ;
       Thread.delay 5.
-  done;
+  done ;
   match !result with
-  | None -> failwith (Printf.sprintf "Repeatedly failed to bind: %s" description)
+  | None ->
+      failwith (Printf.sprintf "Repeatedly failed to bind: %s" description)
   | Some s ->
-    info "Successfully bound socket to: %s" description;
-    s
+      info "Successfully bound socket to: %s" description ;
+      s
 
 (* Maps sockets to Server_io.server records *)
 let socket_table = Hashtbl.create 10
@@ -533,17 +669,20 @@ let socket_table = Hashtbl.create 10
 type socket = Unix.file_descr * string
 
 (* Start an HTTP server on a new socket *)
-let start (x: 'a Server.t) (socket, name) =
-  let handler = { Server_io.name = name;
-                  body = handle_connection x } in
+let start (x : 'a Server.t) (socket, name) =
+  let handler = {Server_io.name; body= handle_connection x} in
   let server = Server_io.server handler socket in
   Hashtbl.add socket_table socket server
 
 exception Socket_not_found
+
 (* Stop an HTTP server running on a socket *)
 let stop (socket, _name) =
-  let server = try Hashtbl.find socket_table socket with Not_found -> raise Socket_not_found in
-  Hashtbl.remove socket_table socket;
+  let server =
+    try Hashtbl.find socket_table socket
+    with Not_found -> raise Socket_not_found
+  in
+  Hashtbl.remove socket_table socket ;
   server.Server_io.shutdown ()
 
 exception Client_requested_size_over_limit
@@ -551,78 +690,87 @@ exception Client_requested_size_over_limit
 (** Read the body of an HTTP request (requires a content-length: header). *)
 let read_body ?limit req bio =
   match req.Request.content_length with
-  | None -> failwith "We require a content-length: HTTP header"
+  | None ->
+      failwith "We require a content-length: HTTP header"
   | Some length ->
-    let length = Int64.to_int length in
-    Option.fold ~none:() ~some:(fun l -> if length > l then raise Client_requested_size_over_limit) limit;
-    if Buf_io.is_buffer_empty bio then Unixext.really_read_string (Buf_io.fd_of bio) length
-    else
-      Buf_io.really_input_buf ~timeout:Buf_io.infinite_timeout bio length
+      let length = Int64.to_int length in
+      Option.fold ~none:()
+        ~some:(fun l ->
+          if length > l then raise Client_requested_size_over_limit)
+        limit ;
+      if Buf_io.is_buffer_empty bio then
+        Unixext.really_read_string (Buf_io.fd_of bio) length
+      else
+        Buf_io.really_input_buf ~timeout:Buf_io.infinite_timeout bio length
 
 module Chunked = struct
-  type t = { mutable current_size : int; mutable current_offset : int;
-             mutable read_headers : bool; bufio : Buf_io.t }
+  type t = {
+      mutable current_size: int
+    ; mutable current_offset: int
+    ; mutable read_headers: bool
+    ; bufio: Buf_io.t
+  }
 
   let of_bufio bufio =
-    { current_size = 0; current_offset = 0; bufio = bufio;
-      read_headers = true }
+    {current_size= 0; current_offset= 0; bufio; read_headers= true}
 
   let rec read chunk size =
-    if chunk.read_headers = true then begin
+    if chunk.read_headers = true then (
       (* first get the size, then get the data requested *)
-      let size = Buf_io.input_line chunk.bufio
+      let size =
+        Buf_io.input_line chunk.bufio
         |> Bytes.to_string
         |> String.trim
         |> Printf.sprintf "0x%s"
         |> int_of_string
       in
-      chunk.current_size <- size;
-      chunk.current_offset <- 0;
-      chunk.read_headers <- false;
-    end ;
-
+      chunk.current_size <- size ;
+      chunk.current_offset <- 0 ;
+      chunk.read_headers <- false
+    ) ;
     (* read as many bytes from this chunk as possible *)
-    if chunk.current_size = 0 then ""
-    else begin
-      let bytes_to_read = min size (chunk.current_size - chunk.current_offset) in
-      if bytes_to_read = 0 then ""
-      else begin
+    if chunk.current_size = 0 then
+      ""
+    else
+      let bytes_to_read =
+        min size (chunk.current_size - chunk.current_offset)
+      in
+      if bytes_to_read = 0 then
+        ""
+      else
         let data = Bytes.make bytes_to_read '\000' in
-        Buf_io.really_input chunk.bufio data 0 bytes_to_read;
-
+        Buf_io.really_input chunk.bufio data 0 bytes_to_read ;
         (* now update the data structure: *)
-        if (chunk.current_offset + bytes_to_read) = chunk.current_size then begin
+        if chunk.current_offset + bytes_to_read = chunk.current_size then (
           (* finished a chunk: get rid of the CRLF *)
-          let blank =Bytes.of_string "\000\000" in
-          Buf_io.really_input chunk.bufio blank 0 2;
-          if (Bytes.to_string blank) <> "\r\n" then failwith "chunked encoding error";
+          let blank = Bytes.of_string "\000\000" in
+          Buf_io.really_input chunk.bufio blank 0 2 ;
+          if Bytes.to_string blank <> "\r\n" then
+            failwith "chunked encoding error" ;
           chunk.read_headers <- true
-        end else begin
-          (* partway through a chunk. *)
-          chunk.current_offset <- (chunk.current_offset + bytes_to_read)
-        end;
-        ( (Bytes.unsafe_to_string data) ^ read chunk (size - bytes_to_read) )
-      end
-    end
+        ) else (* partway through a chunk. *)
+          chunk.current_offset <- chunk.current_offset + bytes_to_read ;
+        Bytes.unsafe_to_string data ^ read chunk (size - bytes_to_read)
 end
 
 let read_chunked_encoding _req bio =
   let rec next () =
-    let size = Buf_io.input_line bio
-               (* Strictly speaking need to kill anything past an ';' if present *)
-               |> Bytes.to_string
-               |> String.trim
-               |> Printf.sprintf "0x%s"
-               |> int_of_string
+    let size =
+      Buf_io.input_line bio
+      (* Strictly speaking need to kill anything past an ';' if present *)
+      |> Bytes.to_string
+      |> String.trim
+      |> Printf.sprintf "0x%s"
+      |> int_of_string
     in
-
-    if size = 0 then Http.End
+    if size = 0 then
+      Http.End
     else
       let chunk = Bytes.make size '\000' in
-      Buf_io.really_input bio chunk 0 size;
+      Buf_io.really_input bio chunk 0 size ;
       (* Then get rid of the CRLF *)
-      let blank = (Bytes.of_string "\000\000") in
-      Buf_io.really_input bio blank 0 2;
+      let blank = Bytes.of_string "\000\000" in
+      Buf_io.really_input bio blank 0 2 ;
       Http.Item (chunk, next)
   in
   next ()

--- a/http-svr/http_svr.mli
+++ b/http-svr/http_svr.mli
@@ -25,37 +25,36 @@ type 'a handler =
 module Stats : sig
   (** Statistics recorded per-handler *)
   type t = {
-    mutable n_requests: int;    (** Total number of requests processed *)
-    mutable n_connections: int; (** Total number of connections accepted *)
-    mutable n_framed: int;      (** using the more efficient framed protocol *)
+      mutable n_requests: int  (** Total number of requests processed *)
+    ; mutable n_connections: int  (** Total number of connections accepted *)
+    ; mutable n_framed: int  (** using the more efficient framed protocol *)
   }
 end
 
 module Server : sig
-
   (** Represents an HTTP server with a set of handlers and set of listening sockets *)
   type 'a t
 
+  val empty : 'a -> 'a t
   (** An HTTP server which sends back a default error response to every request *)
-  val empty: 'a -> 'a t
 
+  val add_handler : 'a t -> Http.method_t -> uri_path -> 'a handler -> unit
   (** [add_handler x m uri h] adds handler [h] to server [x] to serve all requests with
       		method [m] for URI prefix [uri] *)
-  val add_handler : 'a t -> Http.method_t -> uri_path -> 'a handler -> unit
 
+  val find_stats : 'a t -> Http.method_t -> uri_path -> Stats.t option
   (** [find_stats x m uri] returns stats associated with method [m] and uri [uri]
       		in server [x], or None if none exist *)
-  val find_stats: 'a t -> Http.method_t -> uri_path -> Stats.t option
 
+  val all_stats : 'a t -> (Http.method_t * uri_path * Stats.t) list
   (** [all_stats x] returns a list of (method, uri, stats) triples *)
-  val all_stats: 'a t -> (Http.method_t * uri_path * Stats.t) list
 
+  val enable_fastpath : 'a t -> unit
   (** [enable_fastpath x] switches on experimental performance optimisations *)
-  val enable_fastpath: 'a t -> unit
-
 end
 
 exception Too_many_headers
+
 exception Generic_error of string
 
 type socket
@@ -75,10 +74,11 @@ val stop : socket -> unit
 
 exception Client_requested_size_over_limit
 
-module Chunked :
-sig
+module Chunked : sig
   type t
+
   val of_bufio : Buf_io.t -> t
+
   val read : t -> int -> string
 end
 
@@ -87,22 +87,43 @@ val read_chunked_encoding : Http.Request.t -> Buf_io.t -> bytes Http.ll
 (* The rest of this interface needs to be deleted and replaced with Http.Response.* *)
 
 val response_fct :
-  Http.Request.t ->
-  ?hdrs:(string * string) list ->
-  Unix.file_descr -> int64 -> (Unix.file_descr -> unit) -> unit
+     Http.Request.t
+  -> ?hdrs:(string * string) list
+  -> Unix.file_descr
+  -> int64
+  -> (Unix.file_descr -> unit)
+  -> unit
 
 val response_str :
-  Http.Request.t -> ?hdrs:(string * string) list -> Unix.file_descr -> string -> unit
-val response_missing : ?hdrs:(string * string) list -> Unix.file_descr -> string -> unit
-val response_unauthorised : ?req:Http.Request.t -> string -> Unix.file_descr -> unit
+     Http.Request.t
+  -> ?hdrs:(string * string) list
+  -> Unix.file_descr
+  -> string
+  -> unit
+
+val response_missing :
+  ?hdrs:(string * string) list -> Unix.file_descr -> string -> unit
+
+val response_unauthorised :
+  ?req:Http.Request.t -> string -> Unix.file_descr -> unit
+
 val response_forbidden : ?req:Http.Request.t -> Unix.file_descr -> unit
+
 val response_badrequest : ?req:Http.Request.t -> Unix.file_descr -> unit
-val response_internal_error: ?req:Http.Request.t -> ?extra:uri_path -> Unix.file_descr -> unit
-val response_method_not_implemented : ?req:Http.Request.t -> Unix.file_descr -> unit
-val response_file : ?mime_content_type:string -> Unix.file_descr -> string -> unit
+
+val response_internal_error :
+  ?req:Http.Request.t -> ?extra:uri_path -> Unix.file_descr -> unit
+
+val response_method_not_implemented :
+  ?req:Http.Request.t -> Unix.file_descr -> unit
+
+val response_file :
+  ?mime_content_type:string -> Unix.file_descr -> string -> unit
+
 val respond_to_options : Http.Request.t -> Unix.file_descr -> unit
 
 val headers : Unix.file_descr -> string list -> unit
-val read_body : ?limit:int -> Http.Request.t -> Buf_io.t -> string
-val request_of_bio: ?use_fastpath:bool -> Buf_io.t -> Http.Request.t option
 
+val read_body : ?limit:int -> Http.Request.t -> Buf_io.t -> string
+
+val request_of_bio : ?use_fastpath:bool -> Buf_io.t -> Http.Request.t option

--- a/http-svr/http_test.ml
+++ b/http-svr/http_test.ml
@@ -17,54 +17,62 @@ open Http
 
 let test_accept_simple _ =
   let t = Accept.t_of_string "application/json" in
-  assert_equal ~msg:"ty" ~printer:(Option.value ~default:"None") t.Accept.ty (Some "application");
-  assert_equal ~msg:"subty" ~printer:(Option.value ~default:"None") t.Accept.subty (Some "json");
+  assert_equal ~msg:"ty"
+    ~printer:(Option.value ~default:"None")
+    t.Accept.ty (Some "application") ;
+  assert_equal ~msg:"subty"
+    ~printer:(Option.value ~default:"None")
+    t.Accept.subty (Some "json") ;
   assert (Accept.matches ("application", "json") t)
 
 let test_accept_complex _ =
-  let ts = Accept.ts_of_string "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8" in
+  let ts =
+    Accept.ts_of_string
+      "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+  in
   let m = Accept.preferred_match ("text", "html") ts in
-  assert((Option.get m).Accept.ty = Some "text");
+  assert ((Option.get m).Accept.ty = Some "text") ;
   let m = Accept.preferred_match ("foo", "bar") ts in
-  assert((Option.get m).Accept.ty = None)
+  assert ((Option.get m).Accept.ty = None)
 
-let test_strings = [
-  "/import_vdi";
-  "/import_raw_vdi";
-  "/export";
-  "/export_metadata";
-  "/import";
-  "/import_metadata";
-  "/migrate";
-  "/console";
-  "/host_backup";
-  "/host_restore";
-  "/host_logs_download";
-  "/pool_patch_upload";
-  "/oem_patch_stream";
-  "/pool_patch_download";
-  "/sync_config_files";
-  "/pool/xmldbdump";
-  "http";
-  "/vncsnapshot";
-  "/system-status";
-  "/remote_db_access";
-  "/remote_db_access_v2";
-  "/remote_stats";
-  "/json";
-  "/cli";
-  "/vm_rrd";
-  "/rrd";
-  "/host_rrd";
-  "/rrd_updates";
-  "/blob";
-  "/remotecmd";
-  "/rss";
-  "/wlb_report";
-  "/wlb_diagnostics";
-  "/audit_log";
-  "/"
-]
+let test_strings =
+  [
+    "/import_vdi"
+  ; "/import_raw_vdi"
+  ; "/export"
+  ; "/export_metadata"
+  ; "/import"
+  ; "/import_metadata"
+  ; "/migrate"
+  ; "/console"
+  ; "/host_backup"
+  ; "/host_restore"
+  ; "/host_logs_download"
+  ; "/pool_patch_upload"
+  ; "/oem_patch_stream"
+  ; "/pool_patch_download"
+  ; "/sync_config_files"
+  ; "/pool/xmldbdump"
+  ; "http"
+  ; "/vncsnapshot"
+  ; "/system-status"
+  ; "/remote_db_access"
+  ; "/remote_db_access_v2"
+  ; "/remote_stats"
+  ; "/json"
+  ; "/cli"
+  ; "/vm_rrd"
+  ; "/rrd"
+  ; "/host_rrd"
+  ; "/rrd_updates"
+  ; "/blob"
+  ; "/remotecmd"
+  ; "/rss"
+  ; "/wlb_report"
+  ; "/wlb_diagnostics"
+  ; "/audit_log"
+  ; "/"
+  ]
 
 let make_radix_tree () =
   let open Radix_tree in
@@ -77,111 +85,134 @@ let test_radix_tree1 _ =
      	   the right key *)
   List.iter
     (fun x ->
-       if longest_prefix x t <> Some x
-       then failwith (Printf.sprintf "x = %s" x)) test_strings
+      if longest_prefix x t <> Some x then
+        failwith (Printf.sprintf "x = %s" x))
+    test_strings
 
 let test_radix_tree2 _ =
   let open Radix_tree in
   let t = make_radix_tree () in
   let all = fold (fun k _ acc -> k :: acc) [] t in
-  if List.length all <> (List.length test_strings)
-  then failwith "fold"
+  if List.length all <> List.length test_strings then
+    failwith "fold"
 
 let test_url _ =
   let open Http in
   let open Http.Url in
-  begin match of_string "file:/var/xapi/storage" with
-    | File { path = "/var/xapi/storage" }, { uri = "/"; _ } -> ()
-    | _ -> assert false
-  end;
-  begin match of_string "http://root:foo@localhost" with
-    | Http t, { uri = "/"; _ } ->
-      assert (t.auth = Some(Basic("root", "foo")));
-      assert (t.ssl = false);
-      assert (t.host = "localhost");
-    | _ -> assert false
-  end;
-  begin match of_string "https://google.com/gmail" with
-    | Http t, { uri = "/gmail"; _ } ->
-      assert (t.ssl = true);
-      assert (t.host = "google.com");
-    | _ -> assert false
-  end;
-  begin match of_string "https://xapi.xen.org/services/SM" with
-    | Http t, { uri = "/services/SM"; _ } ->
-      assert (t.ssl = true);
-      assert (t.host = "xapi.xen.org");
-    | _ -> assert false
-  end;
-  begin match of_string "https://root:foo@xapi.xen.org:1234/services/SM" with
-    | Http t, { uri = "/services/SM"; _ } ->
-      assert (t.auth = Some(Basic("root", "foo")));
-      assert (t.port = Some 1234);
-      assert (t.ssl = true);
-      assert (t.host = "xapi.xen.org");
-    | _ -> assert false
-  end;
-  begin match of_string "https://xapi.xen.org/services/SM?foo=bar" with
-    | Http t, { uri = "/services/SM"; query_params = [ "foo", "bar" ] } ->
-      assert (t.ssl = true);
-      assert (t.host = "xapi.xen.org");
-    | _ -> assert false
-  end;
-  begin
-    let u = of_string "https://xapi.xen.org/services/SM?foo=bar" in
-    let u' = set_uri u (get_uri u ^ "/data") in
-    let s = to_string u' in
-    assert (s = "https://xapi.xen.org/services/SM/data?foo=bar")
-  end
+  ( match of_string "file:/var/xapi/storage" with
+  | File {path= "/var/xapi/storage"}, {uri= "/"; _} ->
+      ()
+  | _ ->
+      assert false
+  ) ;
+  ( match of_string "http://root:foo@localhost" with
+  | Http t, {uri= "/"; _} ->
+      assert (t.auth = Some (Basic ("root", "foo"))) ;
+      assert (t.ssl = false) ;
+      assert (t.host = "localhost")
+  | _ ->
+      assert false
+  ) ;
+  ( match of_string "https://google.com/gmail" with
+  | Http t, {uri= "/gmail"; _} ->
+      assert (t.ssl = true) ;
+      assert (t.host = "google.com")
+  | _ ->
+      assert false
+  ) ;
+  ( match of_string "https://xapi.xen.org/services/SM" with
+  | Http t, {uri= "/services/SM"; _} ->
+      assert (t.ssl = true) ;
+      assert (t.host = "xapi.xen.org")
+  | _ ->
+      assert false
+  ) ;
+  ( match of_string "https://root:foo@xapi.xen.org:1234/services/SM" with
+  | Http t, {uri= "/services/SM"; _} ->
+      assert (t.auth = Some (Basic ("root", "foo"))) ;
+      assert (t.port = Some 1234) ;
+      assert (t.ssl = true) ;
+      assert (t.host = "xapi.xen.org")
+  | _ ->
+      assert false
+  ) ;
+  ( match of_string "https://xapi.xen.org/services/SM?foo=bar" with
+  | Http t, {uri= "/services/SM"; query_params= [("foo", "bar")]} ->
+      assert (t.ssl = true) ;
+      assert (t.host = "xapi.xen.org")
+  | _ ->
+      assert false
+  ) ;
+  let u = of_string "https://xapi.xen.org/services/SM?foo=bar" in
+  let u' = set_uri u (get_uri u ^ "/data") in
+  let s = to_string u' in
+  assert (s = "https://xapi.xen.org/services/SM/data?foo=bar")
 
 let with_fd input f =
   let read_fd, write_fd = Unix.pipe () in
-  let _:int = Unix.write write_fd (Bytes.of_string input) 0 (String.length input) in
-  Fun.protect ~finally:(fun () -> Unix.close read_fd ; Unix.close write_fd) (fun () -> f read_fd)
+  let (_ : int) =
+    Unix.write write_fd (Bytes.of_string input) 0 (String.length input)
+  in
+  Fun.protect
+    ~finally:(fun () -> Unix.close read_fd ; Unix.close write_fd)
+    (fun () -> f read_fd)
 
 let cross xs ys zs =
-  xs |> List.fold_left (fun acc x ->
-  ys |> List.fold_left (fun acc y ->
-  zs |> List.fold_left (fun acc z -> (x,y,z)::acc) acc) acc) []
+  xs
+  |> List.fold_left
+       (fun acc x ->
+         ys
+         |> List.fold_left
+              (fun acc y ->
+                zs |> List.fold_left (fun acc z -> (x, y, z) :: acc) acc)
+              acc)
+       []
 
 let test_read_http_request_header _ =
   let proxy_str = "TCP6 ::ffff:10.71.152.135 ::ffff:10.71.152.134 53772 443" in
-  let header1 ="\
-POST / HTTP/1.0\r\n\
-content-length: 253\r\n\
-user-agent: xen-api-libs/1.0\r\n\
-connection: keep-alive\r\n\r\n"
+  let header1 =
+    "POST / HTTP/1.0\r\n\
+     content-length: 253\r\n\
+     user-agent: xen-api-libs/1.0\r\n\
+     connection: keep-alive\r\n\
+     \r\n"
   in
-  let header2 ="\
-GET /rrd_updates?session_id=OpaqueRef%3A26930e89-5c3c-4f80-a578-8a5344281532&start=1601481300&cf=AVERAGE&interval=5&host=true HTTP/1.0\r\n\
-Host: 10.71.152.134\r\n\r\n"
+  let header2 =
+    "GET \
+     /rrd_updates?session_id=OpaqueRef%3A26930e89-5c3c-4f80-a578-8a5344281532&start=1601481300&cf=AVERAGE&interval=5&host=true \
+     HTTP/1.0\r\n\
+     Host: 10.71.152.134\r\n\
+     \r\n"
   in
   let mk_header_string ~frame ~proxy ~header =
     let b = Buffer.create 1024 in
-    if proxy then Buffer.add_string b (Printf.sprintf "PROXY %s\r\n" proxy_str);
-    if frame then Buffer.add_string b (Http.make_frame_header header);
+    if proxy then Buffer.add_string b (Printf.sprintf "PROXY %s\r\n" proxy_str) ;
+    if frame then Buffer.add_string b (Http.make_frame_header header) ;
     Buffer.add_string b header ;
     Buffer.to_bytes b |> Bytes.to_string
   in
   let test_cases = cross [true; false] [true; false] [header1; header2] in
   assert (List.length test_cases = 8) ;
-  test_cases |> List.iter (fun (frame, proxy, header) ->
-    with_fd (mk_header_string ~frame ~proxy ~header) (fun fd ->
-      let actual_frame, actual_header, actual_proxy = Http.read_http_request_header fd in
-      assert (actual_frame = frame) ;
-      assert (actual_header = header) ;
-      assert (actual_proxy = if proxy then Some proxy_str else None)
-    )
-  )
+  test_cases
+  |> List.iter (fun (frame, proxy, header) ->
+         with_fd (mk_header_string ~frame ~proxy ~header) (fun fd ->
+             let actual_frame, actual_header, actual_proxy =
+               Http.read_http_request_header fd
+             in
+             assert (actual_frame = frame) ;
+             assert (actual_header = header) ;
+             assert (actual_proxy = if proxy then Some proxy_str else None)))
 
 let _ =
-  let suite = "HTTP test" >:::
-              [
-                "accept_simple" >:: test_accept_simple;
-                "accept_complex" >:: test_accept_complex;
-                "radix1" >:: test_radix_tree1;
-                "radix2" >:: test_radix_tree2;
-                "test_url" >:: test_url;
-                "test_read_http_request_header" >:: test_read_http_request_header;
-              ] in
+  let suite =
+    "HTTP test"
+    >::: [
+           "accept_simple" >:: test_accept_simple
+         ; "accept_complex" >:: test_accept_complex
+         ; "radix1" >:: test_radix_tree1
+         ; "radix2" >:: test_radix_tree2
+         ; "test_url" >:: test_url
+         ; "test_read_http_request_header" >:: test_read_http_request_header
+         ]
+  in
   run_test_tt_main suite

--- a/http-svr/mime.ml
+++ b/http-svr/mime.ml
@@ -23,34 +23,35 @@ let lowercase = Astring.String.Ascii.lowercase
 (** Parse an Apache-format mime.types file and return mime_t *)
 let mime_of_file file =
   let h = Hashtbl.create 1024 in
-  Xapi_stdext_unix.Unixext.readfile_line (fun line ->
-      if not (Astring.String.is_prefix ~affix:"#" line) then begin
+  Xapi_stdext_unix.Unixext.readfile_line
+    (fun line ->
+      if not (Astring.String.is_prefix ~affix:"#" line) then
         match Astring.String.fields ~empty:false line with
-        | [] | [_] -> ()
-        | mime::exts ->
-          List.iter (fun e ->
-              Hashtbl.add h (lowercase e) mime
-            ) exts
-      end
-    ) file;
+        | [] | [_] ->
+            ()
+        | mime :: exts ->
+            List.iter (fun e -> Hashtbl.add h (lowercase e) mime) exts)
+    file ;
   h
 
 let string_of_mime m =
-  String.concat "," (Hashtbl.fold (fun k v a ->
-      sprintf "{%s:%s}" k v :: a) m [])
+  String.concat ","
+    (Hashtbl.fold (fun k v a -> sprintf "{%s:%s}" k v :: a) m [])
 
 let default_mime = "text/plain"
 
 (** Map a file extension to a MIME type *)
 let mime_of_ext mime ext =
-  try Hashtbl.find mime (lowercase ext)
-  with Not_found -> default_mime
+  try Hashtbl.find mime (lowercase ext) with Not_found -> default_mime
 
 (** Figure out a mime type from a full filename *)
 let mime_of_file_name mime fname =
   (* split filename into dot components *)
-  let ext = match Astring.String.cuts ~sep:"." fname with
-    | [] | [_] -> ""
-    | x -> List.hd (List.rev x) in
+  let ext =
+    match Astring.String.cuts ~sep:"." fname with
+    | [] | [_] ->
+        ""
+    | x ->
+        List.hd (List.rev x)
+  in
   mime_of_ext mime ext
-

--- a/http-svr/mime.mli
+++ b/http-svr/mime.mli
@@ -12,8 +12,11 @@
  * GNU Lesser General Public License for more details.
  *)
 type t
-val mime_of_file : string -> t
-val string_of_mime : t -> string
-val mime_of_ext : t -> string -> string
-val mime_of_file_name : t -> string -> string
 
+val mime_of_file : string -> t
+
+val string_of_mime : t -> string
+
+val mime_of_ext : t -> string -> string
+
+val mime_of_file_name : t -> string -> string

--- a/http-svr/radix_tree.ml
+++ b/http-svr/radix_tree.ml
@@ -1,30 +1,28 @@
-
-type 'a t =
-  | Node of string * 'a option * ('a t list)
+type 'a t = Node of string * 'a option * 'a t list
 
 (* Invariant: the only node with an empty string is the root *)
-let empty = Node("", None, [])
+let empty = Node ("", None, [])
 
 let is_prefix a b =
   true
-  && String.length b >= (String.length a)
+  && String.length b >= String.length a
   && String.sub b 0 (String.length a) = a
 
 let common_prefix a b =
-  let j = ref 0 in (* length of common prefix *)
+  let j = ref 0 in
+  (* length of common prefix *)
   let skip = ref false in
   for i = 0 to min (String.length a) (String.length b) - 1 do
-    if not !skip
-    then if a.[i] = b.[i] then incr j else skip := true
-  done;
+    if not !skip then
+      if a.[i] = b.[i] then incr j else skip := true
+  done ;
   String.sub a 0 !j
 
 let sub b a =
-  let length = String.length b - (String.length a) in
+  let length = String.length b - String.length a in
   String.sub b (String.length b - length) length
 
-let string = function
-  | Node(s, _, _) -> s
+let string = function Node (s, _, _) -> s
 
 exception Duplicate_key of string
 
@@ -32,53 +30,66 @@ exception Duplicate_key of string
    safe to examine the first characters of the child strings. Moreover since
    common prefixes are always represented as shared nodes, there can be at most
    one child with the same initial character as the key we're looking up. *)
-let choose remaining ns = match List.partition (fun x -> (string x).[0] = remaining.[0]) ns with
-  | [ n ], rest -> Some(n, rest)
-  | [], _ -> None
-  | _ :: _, _ -> assert false
+let choose remaining ns =
+  match List.partition (fun x -> (string x).[0] = remaining.[0]) ns with
+  | [n], rest ->
+      Some (n, rest)
+  | [], _ ->
+      None
+  | _ :: _, _ ->
+      assert false
 
 let rec insert k v = function
   (* k could be equal to s *)
-  | Node(s, Some _, _) when k = s -> raise (Duplicate_key k)
-  | Node(s, None, ns) when k = s -> Node(s, Some v, ns)
+  | Node (s, Some _, _) when k = s ->
+      raise (Duplicate_key k)
+  | Node (s, None, ns) when k = s ->
+      Node (s, Some v, ns)
   (* k could be a prefix of s *)
-  | Node(s, v', ns) when is_prefix k s ->
-    assert(sub s k <> "");
-    Node(k, Some v, [ Node(sub s k, v', ns) ])
+  | Node (s, v', ns) when is_prefix k s ->
+      assert (sub s k <> "") ;
+      Node (k, Some v, [Node (sub s k, v', ns)])
   (* s could be a prefix of k *)
-  |  Node(s, v', ns) when is_prefix s k ->
-    let remaining = sub k s in
-    assert(remaining <> "");
-    begin match choose remaining ns with
-      | Some (n, rest) -> Node(s, v', insert remaining v n :: rest)
-      | None -> Node(s, v', Node(remaining, Some v, []) :: ns)
-    end
+  | Node (s, v', ns) when is_prefix s k -> (
+      let remaining = sub k s in
+      assert (remaining <> "") ;
+      match choose remaining ns with
+      | Some (n, rest) ->
+          Node (s, v', insert remaining v n :: rest)
+      | None ->
+          Node (s, v', Node (remaining, Some v, []) :: ns)
+    )
   (* s and k could share a non-empty common prefix *)
-  | Node(s, v', ns) ->
-    let p = common_prefix s k in
-    let s' = sub s p and k' = sub k p in
-    assert (s' <> "");
-    assert (k' <> "");
-    Node(p, None, [ Node(s', v', ns); Node(k', Some v, []) ])
+  | Node (s, v', ns) ->
+      let p = common_prefix s k in
+      let s' = sub s p and k' = sub k p in
+      assert (s' <> "") ;
+      assert (k' <> "") ;
+      Node (p, None, [Node (s', v', ns); Node (k', Some v, [])])
 
 let rec fold_over_path f str acc = function
-  | Node(p, v, _) when p = str -> f acc v
-  | Node(p, v, ns) when is_prefix p str ->
-    let remaining = sub str p in
-    begin match choose remaining ns with
-      | Some(n, _) -> fold_over_path f remaining (f acc v) n
-      | None -> f acc v
-    end
-  | _ -> acc
+  | Node (p, v, _) when p = str ->
+      f acc v
+  | Node (p, v, ns) when is_prefix p str -> (
+      let remaining = sub str p in
+      match choose remaining ns with
+      | Some (n, _) ->
+          fold_over_path f remaining (f acc v) n
+      | None ->
+          f acc v
+    )
+  | _ ->
+      acc
 
-let better acc = function | None -> acc | Some x -> Some x
+let better acc = function None -> acc | Some x -> Some x
 
 let longest_prefix str t = fold_over_path better str None t
 
 let fold f acc t =
   let rec inner p acc = function
     | Node (p', v, ns) ->
-      let pp = p ^ p' in
-      let acc = Option.fold ~none:acc ~some:(fun v -> f pp v acc) v in
-      List.fold_left (fun acc n -> inner pp acc n) acc ns in
+        let pp = p ^ p' in
+        let acc = Option.fold ~none:acc ~some:(fun v -> f pp v acc) v in
+        List.fold_left (fun acc n -> inner pp acc n) acc ns
+  in
   inner "" acc t

--- a/http-svr/radix_tree.mli
+++ b/http-svr/radix_tree.mli
@@ -1,24 +1,24 @@
 (** A radix tree mapping strings to ['a]. *)
 type 'a t
 
-(** An empty tree *)
 val empty : 'a t
+(** An empty tree *)
 
 (** [Duplicate_key key] is thrown by [insert] if [key]
     	already exists in the tree. *)
 exception Duplicate_key of string
 
+val insert : string -> 'a -> 'a t -> 'a t
 (** [insert key value tree] returns a new tree with the
     mapping [key] to [value] *)
-val insert : string -> 'a -> 'a t -> 'a t
 
+val longest_prefix : string -> 'a t -> 'a option
 (** [longest_prefix key tree] finds the key [k] which shares
     the longest prefix with [key] and returns the associated
     value. *)
-val longest_prefix : string -> 'a t -> 'a option
 
-(** [fold f initial t] folds [f] over all bindings in [t] *)
 val fold : (string -> 'a -> 'b -> 'b) -> 'b -> 'a t -> 'b
+(** [fold f initial t] folds [f] over all bindings in [t] *)
 
+val is_prefix : string -> string -> bool
 (** [is_prefix a b] returns true if [a] is a prefix of [b] *)
-val is_prefix: string -> string -> bool

--- a/http-svr/radix_tree_test.ml
+++ b/http-svr/radix_tree_test.ml
@@ -1,72 +1,81 @@
 open Radix_tree
 
-let test_strings = [
-  "/import_vdi";
-  "/import_raw_vdi";
-  "/export";
-  "/export_metadata";
-  "/import";
-  "/import_metadata";
-  "/migrate";
-  "/console";
-  "/host_backup";
-  "/host_restore";
-  "/host_logs_download";
-  "/pool_patch_upload";
-  "/oem_patch_stream";
-  "/pool_patch_download";
-  "/sync_config_files";
-  "/pool/xmldbdump";
-  "http";
-  "/vncsnapshot";
-  "/system-status";
-  "/remote_db_access";
-  "/remote_db_access_v2";
-  "/remote_stats";
-  "/json";
-  "/cli";
-  "/vm_rrd";
-  "/rrd";
-  "/host_rrd";
-  "/rrd_updates";
-  "/blob";
-  "/remotecmd";
-  "/rss";
-  "/wlb_report";
-  "/wlb_diagnostics";
-  "/audit_log";
-  "/"
-]
+let test_strings =
+  [
+    "/import_vdi"
+  ; "/import_raw_vdi"
+  ; "/export"
+  ; "/export_metadata"
+  ; "/import"
+  ; "/import_metadata"
+  ; "/migrate"
+  ; "/console"
+  ; "/host_backup"
+  ; "/host_restore"
+  ; "/host_logs_download"
+  ; "/pool_patch_upload"
+  ; "/oem_patch_stream"
+  ; "/pool_patch_download"
+  ; "/sync_config_files"
+  ; "/pool/xmldbdump"
+  ; "http"
+  ; "/vncsnapshot"
+  ; "/system-status"
+  ; "/remote_db_access"
+  ; "/remote_db_access_v2"
+  ; "/remote_stats"
+  ; "/json"
+  ; "/cli"
+  ; "/vm_rrd"
+  ; "/rrd"
+  ; "/host_rrd"
+  ; "/rrd_updates"
+  ; "/blob"
+  ; "/remotecmd"
+  ; "/rss"
+  ; "/wlb_report"
+  ; "/wlb_diagnostics"
+  ; "/audit_log"
+  ; "/"
+  ]
 
 let t = List.fold_left (fun t x -> insert x x t) empty test_strings
 
 (* Check that each string can be found in the structure and maps to
    the right key *)
-let check1 () = List.iter
+let check1 () =
+  List.iter
     (fun x ->
-       if longest_prefix x t <> Some x
-       then failwith (Printf.sprintf "x = %s" x)) test_strings
+      if longest_prefix x t <> Some x then
+        failwith (Printf.sprintf "x = %s" x))
+    test_strings
 
 let check2 () =
   let all = fold (fun k _ acc -> k :: acc) [] t in
-  if List.length all <> (List.length test_strings)
-  then failwith "fold"
+  if List.length all <> List.length test_strings then
+    failwith "fold"
 
 let previous_longest_prefix x =
-  let uris = List.sort (fun a b -> compare (String.length b) (String.length a)) test_strings in
+  let uris =
+    List.sort
+      (fun a b -> compare (String.length b) (String.length a))
+      test_strings
+  in
   try Some (List.find (fun uri -> is_prefix uri x) uris) with _ -> None
 
 let _ =
-  check1 ();
-  check2 ();
+  check1 () ;
+  check2 () ;
   let time n f =
     let start = Unix.gettimeofday () in
     for _ = 0 to n do
       f ()
-    done;
+    done ;
     let t = Unix.gettimeofday () -. start in
-    float_of_int n /. t in (* ops per sec *)
-  let before = time 1000000 (fun () -> ignore(previous_longest_prefix "/")) in
-  let after = time 1000000 (fun () -> ignore(longest_prefix "/" t)) in
-  Printf.printf "Before: %.1f lookups/sec\n" before;
+    float_of_int n /. t
+  in
+  (* ops per sec *)
+  let before = time 1000000 (fun () -> ignore (previous_longest_prefix "/")) in
+  let after = time 1000000 (fun () -> ignore (longest_prefix "/" t)) in
+  Printf.printf "Before: %.1f lookups/sec\n" before ;
   Printf.printf "After: %.1f lookups/sec\n" after

--- a/http-svr/server_io.ml
+++ b/http-svr/server_io.ml
@@ -15,21 +15,21 @@
 (* open Unix *)
 open Xapi_stdext_pervasives.Pervasiveext
 
-module D = Debug.Make(struct let name = "server_io" end)
+module D = Debug.Make (struct let name = "server_io" end)
+
 open D
 
 type handler = {
-  name: string;
-  (* body should close the provided fd *)
-  body: Unix.sockaddr -> Unix.file_descr -> unit
+    name: string
+  ; (* body should close the provided fd *)
+    body: Unix.sockaddr -> Unix.file_descr -> unit
 }
 
-let handler_by_thread (h: handler) (s: Unix.file_descr) (caller: Unix.sockaddr) = 
+let handler_by_thread (h : handler) (s : Unix.file_descr)
+    (caller : Unix.sockaddr) =
   Thread.create
-    (fun ()->
-       Debug.with_thread_named h.name (fun () -> h.body caller s) ()
-    ) ()  
-
+    (fun () -> Debug.with_thread_named h.name (fun () -> h.body caller s) ())
+    ()
 
 (** Function with the main accept loop *)
 
@@ -38,83 +38,96 @@ exception PleaseClose
 let set_intersect a b = List.filter (fun x -> List.mem x b) a
 
 (** Establish a server; handler is either 'by_thread' or 'in_this_thread' *)
-type sock_or_addr = Server_sockaddr of Unix.sockaddr | Server_fd of Unix.file_descr
-let establish_server ?(signal_fds=[]) forker sockoraddr =
+type sock_or_addr =
+  | Server_sockaddr of Unix.sockaddr
+  | Server_fd of Unix.file_descr
+
+let establish_server ?(signal_fds = []) forker sockoraddr =
   let sock =
     match sockoraddr with
-      Server_sockaddr sockaddr ->
-      let domain = match sockaddr with
-        | ADDR_UNIX _ -> (debug "Establishing Unix domain server"; Unix.PF_UNIX)
-        | ADDR_INET(_,_) -> (debug "Establishing inet domain server"; Unix.PF_INET) in
-      let sock = Unix.socket domain Unix.SOCK_STREAM 0 in
-      Unix.set_close_on_exec sock;
-      Unix.setsockopt sock Unix.SO_REUSEADDR true;
-      Unix.bind sock sockaddr;
-      Unix.listen sock 5;
-      sock
-    | Server_fd fd -> fd in
-  while true do  
+    | Server_sockaddr sockaddr ->
+        let domain =
+          match sockaddr with
+          | ADDR_UNIX _ ->
+              debug "Establishing Unix domain server" ;
+              Unix.PF_UNIX
+          | ADDR_INET (_, _) ->
+              debug "Establishing inet domain server" ;
+              Unix.PF_INET
+        in
+        let sock = Unix.socket domain Unix.SOCK_STREAM 0 in
+        Unix.set_close_on_exec sock ;
+        Unix.setsockopt sock Unix.SO_REUSEADDR true ;
+        Unix.bind sock sockaddr ;
+        Unix.listen sock 5 ;
+        sock
+    | Server_fd fd ->
+        fd
+  in
+  while true do
     try
-      let r, _, _ = Unix.select ([ sock ] @ signal_fds) [] [] (-1.) in
+      let r, _, _ = Unix.select ([sock] @ signal_fds) [] [] (-1.) in
       (* If any of the signal_fd is active then bail out *)
-      if set_intersect r signal_fds <> [] then raise PleaseClose;
-
-      let (s, caller) = Unix.accept sock in
-      begin
-        try 
-          Unix.set_close_on_exec s;
-          ignore(forker s caller)	
-        with exc -> 
-          (* NB provided 'forker' is configured to make a background thread then the
-             	     only way we can get here is if set_close_on_exec or Thread.create fails.
-             	     This means we haven't executed any code which could close the fd therefore
-             	     we should do it ourselves. *)
-          debug "Got exception in server_io.ml: %s" (Printexc.to_string exc);
-          log_backtrace ();
-          Unix.close s;
-          Thread.delay 30.0
-      end
-    with 
+      if set_intersect r signal_fds <> [] then raise PleaseClose ;
+      let s, caller = Unix.accept sock in
+      try
+        Unix.set_close_on_exec s ;
+        ignore (forker s caller)
+      with exc ->
+        (* NB provided 'forker' is configured to make a background thread then the
+           	     only way we can get here is if set_close_on_exec or Thread.create fails.
+           	     This means we haven't executed any code which could close the fd therefore
+           	     we should do it ourselves. *)
+        debug "Got exception in server_io.ml: %s" (Printexc.to_string exc) ;
+        log_backtrace () ;
+        Unix.close s ;
+        Thread.delay 30.0
+    with
     | PleaseClose ->
-      debug "Caught PleaseClose: shutting down server thread";
-      raise PleaseClose
-    | Unix.Unix_error(err, a, b) ->
-      debug "Caught Unix exception in accept: %s in %s %s" (Unix.error_message err) a b;
-      Thread.delay 10.
+        debug "Caught PleaseClose: shutting down server thread" ;
+        raise PleaseClose
+    | Unix.Unix_error (err, a, b) ->
+        debug "Caught Unix exception in accept: %s in %s %s"
+          (Unix.error_message err) a b ;
+        Thread.delay 10.
     | e ->
-      debug "Caught exception in except: %s" (Printexc.to_string e);
-      Thread.delay 10.
+        debug "Caught exception in except: %s" (Printexc.to_string e) ;
+        Thread.delay 10.
   done
 
-type server = { 
-  shutdown : unit -> unit
-}
+type server = {shutdown: unit -> unit}
 
-let server handler sock = 
-  let status_out, status_in = Unix.pipe() in
-  let toclose = ref [ sock; status_in; status_out ] in
-  let close' fd = 
-    if List.mem fd !toclose then begin
-      toclose := List.filter (fun x -> x <> fd) !toclose;
-      (try Unix.close fd with exn -> warn "Caught exn in Server_io.server: %s" (Printexc.to_string exn))
-    end else warn "Attempt to double-shutdown Server_io.server detected; ignoring" in
-  let thread = Thread.create 
+let server handler sock =
+  let status_out, status_in = Unix.pipe () in
+  let toclose = ref [sock; status_in; status_out] in
+  let close' fd =
+    if List.mem fd !toclose then (
+      toclose := List.filter (fun x -> x <> fd) !toclose ;
+      try Unix.close fd
+      with exn ->
+        warn "Caught exn in Server_io.server: %s" (Printexc.to_string exn)
+    ) else
+      warn "Attempt to double-shutdown Server_io.server detected; ignoring"
+  in
+  let thread =
+    Thread.create
       (fun () ->
-         Debug.with_thread_named handler.name
-           (fun () ->
-              try
-                establish_server ~signal_fds:[status_out] (handler_by_thread handler) (Server_fd sock)
-              with PleaseClose ->
-                debug "Server thread exiting") ()
-      ) () in
-  let shutdown () = 
-    finally 
+        Debug.with_thread_named handler.name
+          (fun () ->
+            try
+              establish_server ~signal_fds:[status_out]
+                (handler_by_thread handler)
+                (Server_fd sock)
+            with PleaseClose -> debug "Server thread exiting")
+          ())
+      ()
+  in
+  let shutdown () =
+    finally
       (fun () ->
-         let len = Unix.write status_in (Bytes.of_string "!") 0 1 in
-         if len <> 1 then failwith "Failed to signal to server to shutdown";
-         Thread.join thread)
-      (fun () ->
-         List.iter close' !toclose
-      ) in
-  { shutdown = shutdown }
-
+        let len = Unix.write status_in (Bytes.of_string "!") 0 1 in
+        if len <> 1 then failwith "Failed to signal to server to shutdown" ;
+        Thread.join thread)
+      (fun () -> List.iter close' !toclose)
+  in
+  {shutdown}

--- a/http-svr/server_io.mli
+++ b/http-svr/server_io.mli
@@ -13,14 +13,14 @@
  *)
 
 type handler = {
-  name: string;                                  (** used for naming the thread *)
-  body: Unix.sockaddr -> Unix.file_descr -> unit (** function called in a thread for each connection*)
+    name: string  (** used for naming the thread *)
+  ; body: Unix.sockaddr -> Unix.file_descr -> unit
+        (** function called in a thread for each connection*)
 }
 
-type server = { 
-  shutdown : unit -> unit                        (** clean shutdown, blocks until thread has gone *)
+type server = {
+    shutdown: unit -> unit  (** clean shutdown, blocks until thread has gone *)
 }
 
-(** Creates a server given a bound socket and a handler *)
 val server : handler -> Unix.file_descr -> server
-
+(** Creates a server given a bound socket and a handler *)

--- a/http-svr/test_client.ml
+++ b/http-svr/test_client.ml
@@ -14,90 +14,78 @@ let user_agent = "test_client"
 
 let with_connection ip port f =
   let inet_addr = Unix.inet_addr_of_string ip in
-  let addr = Unix.ADDR_INET(inet_addr, port) in
+  let addr = Unix.ADDR_INET (inet_addr, port) in
   let s = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-  begin
-    try
-      Unix.connect s addr;
-    with e ->
-      Unix.close s;
-      raise e
-  end;
-  Unixext.set_tcp_nodelay s true;
-  finally
-    (fun () -> f s)
-    (fun () -> Unix.close s)
+  (try Unix.connect s addr with e -> Unix.close s ; raise e) ;
+  Unixext.set_tcp_nodelay s true ;
+  finally (fun () -> f s) (fun () -> Unix.close s)
 
-let with_stunnel ip port =
-  fun f ->
-    Stunnel.with_connect ~use_fork_exec_helper:false ~extended_diagnosis:false ip port @@
-    fun s ->
-      let fd = s.Stunnel.fd in
-      f Unixfd.(!fd)
+let with_stunnel ip port f =
+  Stunnel.with_connect ~use_fork_exec_helper:false ~extended_diagnosis:false ip
+    port
+  @@ fun s ->
+  let fd = s.Stunnel.fd in
+  f Unixfd.(!fd)
 
 let one ~use_fastpath ~use_framing keep_alive s =
-  Http_client.rpc ~use_fastpath s (Http.Request.make ~frame:use_framing ~version:"1.1" ~keep_alive
-                                     ~user_agent ~body:"hello" Http.Post "/echo")
-    (fun response s ->
-       match response.Http.Response.content_length with
-       | Some l ->
-         let (_: string) = Unixext.really_read_string s (Int64.to_int l) in
-(*
+  Http_client.rpc ~use_fastpath s
+    (Http.Request.make ~frame:use_framing ~version:"1.1" ~keep_alive ~user_agent
+       ~body:"hello" Http.Post "/echo") (fun response s ->
+      match response.Http.Response.content_length with
+      | Some l ->
+          let (_ : string) = Unixext.really_read_string s (Int64.to_int l) in
+          (*
 					Printf.printf "Read [%s]\n" x;
 					flush stdout
 *)
-         ()
-       | None -> failwith "Need a content length"
-    )
+          ()
+      | None ->
+          failwith "Need a content length")
 
 module Normal_population = struct
   (** Stats on a normally-distributed population *)
-  type t = { sigma_x: float;
-             sigma_xx: float;
-             n: int }
+  type t = {sigma_x: float; sigma_xx: float; n: int}
 
-  let empty = { sigma_x = 0.; sigma_xx = 0.; n = 0 }
+  let empty = {sigma_x= 0.; sigma_xx= 0.; n= 0}
 
-  let sample (p: t) (x: float) : t =
-    { sigma_x = p.sigma_x +. x;
-      sigma_xx = p.sigma_xx +. x *. x;
-      n = p.n + 1 }
+  let sample (p : t) (x : float) : t =
+    {sigma_x= p.sigma_x +. x; sigma_xx= p.sigma_xx +. (x *. x); n= p.n + 1}
 
   exception Unknown
 
-  let mean (p: t) : float = p.sigma_x /. (float_of_int p.n)
-  let sd (p: t) : float =
-    if p.n = 0
-    then raise Unknown
+  let mean (p : t) : float = p.sigma_x /. float_of_int p.n
+
+  let sd (p : t) : float =
+    if p.n = 0 then
+      raise Unknown
     else
       let n = float_of_int p.n in
-      sqrt (n *. p.sigma_xx -. p.sigma_x *. p.sigma_x) /. n
+      sqrt ((n *. p.sigma_xx) -. (p.sigma_x *. p.sigma_x)) /. n
 
-  let to_string (p: t) = Printf.sprintf "%.1f +/- %.1f" (mean p) (sd p)
+  let to_string (p : t) = Printf.sprintf "%.1f +/- %.1f" (mean p) (sd p)
 end
 
 let per_nsec n f =
   let start = Unix.gettimeofday () in
   let t = ref 0 in
   while Unix.gettimeofday () -. start < n do
-    f ();
-    incr t
-  done;
+    f () ; incr t
+  done ;
   int_of_float (float_of_int !t /. n)
 
 let threads n f =
   let results = Array.make n 0 in
   let body i () = results.(i) <- f () in
   let threads = Array.mapi (fun i _ -> Thread.create (body i) ()) results in
-  Array.iter Thread.join threads;
-  Array.fold_left (+) 0 results
+  Array.iter Thread.join threads ;
+  Array.fold_left ( + ) 0 results
 
 let sample n f =
   let p = ref Normal_population.empty in
   for _ = 1 to n do
     let v = f () in
-    p := Normal_population.sample !p (float_of_int v);
-  done;
+    p := Normal_population.sample !p (float_of_int v)
+  done ;
   !p
 
 let _ =
@@ -106,59 +94,53 @@ let _ =
   let use_ssl = ref false in
   let use_fastpath = ref false in
   let use_framing = ref false in
-  Arg.parse [
-    "-ip", Arg.Set_string ip, "IP to connect to";
-    "-p", Arg.Set_int port, "port to connect";
-    "-fast", Arg.Set use_fastpath, "use HTTP fastpath";
-    "-frame", Arg.Set use_framing, "use HTTP framing";
-    "--ssl", Arg.Set use_ssl, "use SSL rather than plaintext";
-  ] (fun x -> Printf.fprintf stderr "Ignoring unexpected argument: %s\n" x)
-    "A simple test HTTP client";
+  Arg.parse
+    [
+      ("-ip", Arg.Set_string ip, "IP to connect to")
+    ; ("-p", Arg.Set_int port, "port to connect")
+    ; ("-fast", Arg.Set use_fastpath, "use HTTP fastpath")
+    ; ("-frame", Arg.Set use_framing, "use HTTP framing")
+    ; ("--ssl", Arg.Set use_ssl, "use SSL rather than plaintext")
+    ]
+    (fun x -> Printf.fprintf stderr "Ignoring unexpected argument: %s\n" x)
+    "A simple test HTTP client" ;
   let use_fastpath = !use_fastpath in
   let use_framing = !use_framing in
   let transport = if !use_ssl then with_stunnel else with_connection in
-(*
+  (*
 	Printf.printf "Overhead of timing:                ";
 	let overhead = sample 10 (fun () -> per_nsec 1. (fun () -> ())) in
 	Printf.printf "%s ops/sec\n" (Normal_population.to_string overhead);
 *)
-  Printf.printf "1 thread non-persistent connections:        ";
-  let nonpersistent = sample 1
-      (fun () -> per_nsec 1.
-          (fun () -> transport !ip !port (one ~use_fastpath ~use_framing false))) in
-  Printf.printf "%s RPCs/sec\n%!" (Normal_population.to_string nonpersistent);
-  Printf.printf "10 threads non-persistent connections: ";
+  Printf.printf "1 thread non-persistent connections:        " ;
+  let nonpersistent =
+    sample 1 (fun () ->
+        per_nsec 1. (fun () ->
+            transport !ip !port (one ~use_fastpath ~use_framing false)))
+  in
+  Printf.printf "%s RPCs/sec\n%!" (Normal_population.to_string nonpersistent) ;
+  Printf.printf "10 threads non-persistent connections: " ;
   let thread_nonpersistent =
-    sample 1
-      (fun () ->
-         threads 10
-           (fun () ->
-              per_nsec 5.
-                (fun () ->
-                   transport !ip !port
-                     (one ~use_fastpath ~use_framing false)
-                )
-           )
-      ) in
-  Printf.printf "%s RPCs/sec\n%!" (Normal_population.to_string thread_nonpersistent);
-
-  Printf.printf "1 thread persistent connection:             ";
-  let persistent = sample 1
-      (fun () -> transport !ip !port
-          (fun s -> per_nsec 1. (fun () -> one ~use_fastpath ~use_framing true s))) in
-  Printf.printf "%s RPCs/sec\n%!" (Normal_population.to_string persistent);
-  Printf.printf "10 threads persistent connections: ";
+    sample 1 (fun () ->
+        threads 10 (fun () ->
+            per_nsec 5. (fun () ->
+                transport !ip !port (one ~use_fastpath ~use_framing false))))
+  in
+  Printf.printf "%s RPCs/sec\n%!"
+    (Normal_population.to_string thread_nonpersistent) ;
+  Printf.printf "1 thread persistent connection:             " ;
+  let persistent =
+    sample 1 (fun () ->
+        transport !ip !port (fun s ->
+            per_nsec 1. (fun () -> one ~use_fastpath ~use_framing true s)))
+  in
+  Printf.printf "%s RPCs/sec\n%!" (Normal_population.to_string persistent) ;
+  Printf.printf "10 threads persistent connections: " ;
   let thread_persistent =
-    sample 1
-      (fun () ->
-         threads 10
-           (fun () ->
-              transport !ip !port
-                (fun s ->
-                   per_nsec 5.
-                     (fun () -> one ~use_fastpath ~use_framing true s)
-                )
-           )
-      ) in
-  Printf.printf "%s RPCs/sec\n%!" (Normal_population.to_string thread_persistent);
-
+    sample 1 (fun () ->
+        threads 10 (fun () ->
+            transport !ip !port (fun s ->
+                per_nsec 5. (fun () -> one ~use_fastpath ~use_framing true s))))
+  in
+  Printf.printf "%s RPCs/sec\n%!"
+    (Normal_population.to_string thread_persistent)

--- a/http-svr/test_client.ml
+++ b/http-svr/test_client.ml
@@ -21,8 +21,8 @@ let with_connection ip port f =
   finally (fun () -> f s) (fun () -> Unix.close s)
 
 let with_stunnel ip port f =
-  Stunnel.with_connect ~use_fork_exec_helper:false ~extended_diagnosis:false ip
-    port
+  Stunnel.with_connect ~verify_cert:None ~use_fork_exec_helper:false
+    ~extended_diagnosis:false ip port
   @@ fun s ->
   let fd = s.Stunnel.fd in
   f Unixfd.(!fd)

--- a/http-svr/test_server.ml
+++ b/http-svr/test_server.ml
@@ -2,63 +2,73 @@ open Xapi_stdext_threads.Threadext
 open Xapi_stdext_unix
 
 let finished = ref false
+
 let finished_m = Mutex.create ()
+
 let finished_c = Condition.create ()
 
 let _ =
   let port = ref 8080 in
   let use_fastpath = ref false in
-  Arg.parse [
-    "-p", Arg.Set_int port, "port to listen on";
-    "-fast", Arg.Set use_fastpath, "use HTTP fastpath";
-  ] (fun x -> Printf.fprintf stderr "Ignoring unexpected argument: %s\n" x)
-    "A simple test HTTP server";
+  Arg.parse
+    [
+      ("-p", Arg.Set_int port, "port to listen on")
+    ; ("-fast", Arg.Set use_fastpath, "use HTTP fastpath")
+    ]
+    (fun x -> Printf.fprintf stderr "Ignoring unexpected argument: %s\n" x)
+    "A simple test HTTP server" ;
   let open Http_svr in
   let server = Server.empty () in
-  if !use_fastpath then Server.enable_fastpath server;
-
-  Server.add_handler server Http.Get "/stop" (FdIO
-                                                (fun _ s _ ->
-                                                   let r = Http.Response.to_wire_string (Http.Response.make "200" "OK") in
-                                                   Unixext.really_write_string s r;
-                                                   Mutex.execute finished_m
-                                                     (fun () ->
-                                                        finished := true;
-                                                        Condition.signal finished_c
-                                                     )
-                                                )
-                                             );
-  Server.add_handler server Http.Post "/echo" (FdIO
-                                                 (fun request s _ ->
-                                                    match request.Http.Request.content_length with
-                                                    | None ->
-                                                      Unixext.really_write_string s (Http.Response.to_wire_string (Http.Response.make "404" "content length missing"))
-                                                    | Some l ->
-                                                      let txt = Unixext.really_read_string s (Int64.to_int l) in
-                                                      let r = Http.Response.to_wire_string (Http.Response.make ~body:txt "200" "OK") in
-                                                      Unixext.really_write_string s r
-                                                 )
-                                              );
-  Server.add_handler server Http.Get "/stats" (FdIO
-                                                 (fun _ s _ ->
-                                                    let lines = List.map (fun (m, uri, s) ->
-                                                        Printf.sprintf "%s,%s,%d,%d\n" (Http.string_of_method_t m) uri s.Http_svr.Stats.n_requests s.Http_svr.Stats.n_connections
-                                                      ) (Server.all_stats server) in
-                                                    let txt = String.concat "" lines in
-                                                    let r = Http.Response.to_wire_string (Http.Response.make ~body:txt "200" "OK") in
-                                                    Unixext.really_write_string s r
-                                                 )
-                                              );
-
+  if !use_fastpath then Server.enable_fastpath server ;
+  Server.add_handler server Http.Get "/stop"
+    (FdIO
+       (fun _ s _ ->
+         let r = Http.Response.to_wire_string (Http.Response.make "200" "OK") in
+         Unixext.really_write_string s r ;
+         Mutex.execute finished_m (fun () ->
+             finished := true ;
+             Condition.signal finished_c))) ;
+  Server.add_handler server Http.Post "/echo"
+    (FdIO
+       (fun request s _ ->
+         match request.Http.Request.content_length with
+         | None ->
+             Unixext.really_write_string s
+               (Http.Response.to_wire_string
+                  (Http.Response.make "404" "content length missing"))
+         | Some l ->
+             let txt = Unixext.really_read_string s (Int64.to_int l) in
+             let r =
+               Http.Response.to_wire_string
+                 (Http.Response.make ~body:txt "200" "OK")
+             in
+             Unixext.really_write_string s r)) ;
+  Server.add_handler server Http.Get "/stats"
+    (FdIO
+       (fun _ s _ ->
+         let lines =
+           List.map
+             (fun (m, uri, s) ->
+               Printf.sprintf "%s,%s,%d,%d\n"
+                 (Http.string_of_method_t m)
+                 uri s.Http_svr.Stats.n_requests s.Http_svr.Stats.n_connections)
+             (Server.all_stats server)
+         in
+         let txt = String.concat "" lines in
+         let r =
+           Http.Response.to_wire_string
+             (Http.Response.make ~body:txt "200" "OK")
+         in
+         Unixext.really_write_string s r)) ;
   let ip = "0.0.0.0" in
   let inet_addr = Unix.inet_addr_of_string ip in
-  let addr = Unix.ADDR_INET(inet_addr, !port) in
+  let addr = Unix.ADDR_INET (inet_addr, !port) in
   let socket = Http_svr.bind ~listen_backlog:5 addr "server" in
-  start server socket;
-  Printf.printf "Server started on %s:%d\n" ip !port;
-  Mutex.execute finished_m
-    (fun () ->
-       while not(!finished) do Condition.wait finished_c finished_m done
-    );
-  Printf.printf "Exiting\n";
+  start server socket ;
+  Printf.printf "Server started on %s:%d\n" ip !port ;
+  Mutex.execute finished_m (fun () ->
+      while not !finished do
+        Condition.wait finished_c finished_m
+      done) ;
+  Printf.printf "Exiting\n" ;
   stop socket

--- a/http-svr/ws_helpers.ml
+++ b/http-svr/ws_helpers.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-(* Portions of this code are distributed under the following copyright notice *) 
+(* Portions of this code are distributed under the following copyright notice *)
 (*----------------------------------------------------------------------------
    Copyright (c) 2009-11, Daniel C. Bünzli. All rights reserved.
    Distributed under a BSD license, see license at the end of the file.
@@ -25,66 +25,75 @@
  * connection to a websockets connection 
  * See for reference:
  * http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-17 
-*)
+ *)
 
-type protocol = | Hixie76 | Hybi10
+type protocol = Hixie76 | Hybi10
 
 (* Defined in the websockets protocol document *)
-let ws_uuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" 
+let ws_uuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 let http_101_websocket_upgrade_76 origin host protocol uri =
-  let extra = match protocol with 
-    | Some x -> [ Printf.sprintf "Sec-WebSocket-Protocol: %s" x ]
-    | None -> []
+  let extra =
+    match protocol with
+    | Some x ->
+        [Printf.sprintf "Sec-WebSocket-Protocol: %s" x]
+    | None ->
+        []
   in
-  [ "HTTP/1.0 101 WebSocket Protocol Handshake";
-    "Upgrade: WebSocket";
-    "Connection: Upgrade";
-    Printf.sprintf "Sec-WebSocket-Origin: %s" origin;
-    Printf.sprintf "Sec-WebSocket-Location: ws://%s%s" host uri; ] 
-  @ extra @ [""]
+  [
+    "HTTP/1.0 101 WebSocket Protocol Handshake"
+  ; "Upgrade: WebSocket"
+  ; "Connection: Upgrade"
+  ; Printf.sprintf "Sec-WebSocket-Origin: %s" origin
+  ; Printf.sprintf "Sec-WebSocket-Location: ws://%s%s" host uri
+  ]
+  @ extra
+  @ [""]
 
-
-let http_101_websocket_upgrade_15 key  =
-  [ "HTTP/1.0 101 Switching Protocols";
-    "Upgrade: websocket";
-    "Connection: Upgrade";
-    Printf.sprintf "Sec-WebSocket-Accept: %s" key;
-    "Sec-WebSocket-Protocol: binary"; "" ]
+let http_101_websocket_upgrade_15 key =
+  [
+    "HTTP/1.0 101 Switching Protocols"
+  ; "Upgrade: websocket"
+  ; "Connection: Upgrade"
+  ; Printf.sprintf "Sec-WebSocket-Accept: %s" key
+  ; "Sec-WebSocket-Protocol: binary"
+  ; ""
+  ]
 
 exception MissingHeader of string
 
-
 let find_header headers header_name =
-  try 
-    List.assoc header_name headers
-  with _ ->
-    raise (MissingHeader header_name)
+  try List.assoc header_name headers
+  with _ -> raise (MissingHeader header_name)
 
 let extract_numbers str =
-  let num = Astring.String.filter (function '0'..'9' -> true | _ -> false) str in
+  let num =
+    Astring.String.filter (function '0' .. '9' -> true | _ -> false) str
+  in
   Int64.of_string num
 
 let count_spaces str =
-  Astring.String.fold_left (fun acc -> function ' ' -> acc + 1 | _ -> acc) 0 str
+  Astring.String.fold_left
+    (fun acc -> function ' ' -> acc + 1 | _ -> acc)
+    0 str
 
-let marshal_int32 x = 
-  let offsets = [|3;2;1;0|] in
-  let (>!>) a b = Int32.shift_right_logical a b
-  and (&&) a b = Int32.logand a b in
-  let a = (x >!> 0) && 0xffl 
-  and b = (x >!> 8) && 0xffl
-  and c = (x >!> 16) && 0xffl
-  and d = (x >!> 24) && 0xffl in
+let marshal_int32 x =
+  let offsets = [|3; 2; 1; 0|] in
+  let ( >!> ) a b = Int32.shift_right_logical a b
+  and ( && ) a b = Int32.logand a b in
+  let a = x >!> 0 && 0xffl
+  and b = x >!> 8 && 0xffl
+  and c = x >!> 16 && 0xffl
+  and d = x >!> 24 && 0xffl in
   let s = Bytes.make 4 '\000' in
-  Bytes.set s offsets.(0) @@ char_of_int (Int32.to_int a);
-  Bytes.set s offsets.(1) @@ char_of_int (Int32.to_int b);
-  Bytes.set s offsets.(2) @@ char_of_int (Int32.to_int c);
-  Bytes.set s offsets.(3) @@ char_of_int (Int32.to_int d);
+  Bytes.set s offsets.(0) @@ char_of_int (Int32.to_int a) ;
+  Bytes.set s offsets.(1) @@ char_of_int (Int32.to_int b) ;
+  Bytes.set s offsets.(2) @@ char_of_int (Int32.to_int c) ;
+  Bytes.set s offsets.(3) @@ char_of_int (Int32.to_int d) ;
   Bytes.unsafe_to_string s
 
 let v10_upgrade req s =
-  let headers = req.Http.Request.additional_headers in 
+  let headers = req.Http.Request.additional_headers in
   let key = find_header headers "sec-websocket-key" in
   (*let vsn = find_header headers "sec-websocket-version" in*)
   let result = key ^ ws_uuid |> Sha1.string |> Sha1.to_bin in
@@ -92,8 +101,8 @@ let v10_upgrade req s =
   let headers = http_101_websocket_upgrade_15 key in
   Http.output_http s headers
 
-let hixie_v76_upgrade req s = 
-  let headers = req.Http.Request.additional_headers in 
+let hixie_v76_upgrade req s =
+  let headers = req.Http.Request.additional_headers in
   let sec_websocket_key1 = find_header headers "sec-websocket-key1" in
   let sec_websocket_key2 = find_header headers "sec-websocket-key2" in
   let n1 = extract_numbers sec_websocket_key1 in
@@ -102,27 +111,36 @@ let hixie_v76_upgrade req s =
   let s2 = count_spaces sec_websocket_key2 in
   let v1 = Int64.to_int32 (Int64.div n1 (Int64.of_int s1)) in
   let v2 = Int64.to_int32 (Int64.div n2 (Int64.of_int s2)) in
-
   let s1 = marshal_int32 v1 in
   let s2 = marshal_int32 v2 in
   let s3 = Bytes.make 8 '\000' in
-  Xapi_stdext_unix.Unixext.really_read s s3 0 8;
+  Xapi_stdext_unix.Unixext.really_read s s3 0 8 ;
   let string = Printf.sprintf "%s%s%s" s1 s2 (Bytes.unsafe_to_string s3) in
   let digest = Digest.string string in
-
   let host = find_header headers "host" in
   let origin = find_header headers "origin" in
-  let protocol = try Some (find_header headers "sec-websocket-protocol") with _ -> None in
-  let real_uri = req.Http.Request.uri ^ "?" ^ (String.concat "&" (List.map (fun (x,y) -> Printf.sprintf "%s=%s" x y) req.Http.Request.query)) in
+  let protocol =
+    try Some (find_header headers "sec-websocket-protocol") with _ -> None
+  in
+  let real_uri =
+    req.Http.Request.uri
+    ^ "?"
+    ^ String.concat "&"
+        (List.map
+           (fun (x, y) -> Printf.sprintf "%s=%s" x y)
+           req.Http.Request.query)
+  in
   let headers = http_101_websocket_upgrade_76 origin host protocol real_uri in
-  Http.output_http s headers;
-  Unix.write s (Bytes.unsafe_of_string digest) 0 16 
-  |> ignore
+  Http.output_http s headers ;
+  Unix.write s (Bytes.unsafe_of_string digest) 0 16 |> ignore
 
-let upgrade req s = 
-  if List.mem_assoc "sec-websocket-key1" req.Http.Request.additional_headers 
-  then (hixie_v76_upgrade req s; Hixie76)
-  else (v10_upgrade req s; Hybi10)
+let upgrade req s =
+  if List.mem_assoc "sec-websocket-key1" req.Http.Request.additional_headers
+  then (
+    hixie_v76_upgrade req s ; Hixie76
+  ) else (
+    v10_upgrade req s ; Hybi10
+  )
 
 (* The following copyright notice is relevant to the function marked above *)
 

--- a/http-svr/ws_helpers.mli
+++ b/http-svr/ws_helpers.mli
@@ -14,6 +14,6 @@
 
 exception MissingHeader of string
 
-type protocol = | Hixie76 | Hybi10
+type protocol = Hixie76 | Hybi10
 
 val upgrade : Http.Request.t -> Unix.file_descr -> protocol

--- a/http-svr/xMLRPC.ml
+++ b/http-svr/xMLRPC.ml
@@ -11,43 +11,51 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module D=Debug.Make(struct let name="xmlrpc" end)
+module D = Debug.Make (struct let name = "xmlrpc" end)
+
 open D
 
 exception RunTimeTypeError of string * Xml.xml
 
 let rtte name xml =
-  error "Error: name='%s'; xml= %s" name (String.escaped (Xml.to_string xml));
-  raise (RunTimeTypeError(name, xml))
+  error "Error: name='%s'; xml= %s" name (String.escaped (Xml.to_string xml)) ;
+  raise (RunTimeTypeError (name, xml))
 
 type xmlrpc = Xml.xml
 
 let pretty_print = function
-  | Xml.Element(tag,_,_) -> "Element=" ^ String.escaped tag
-  | Xml.PCData d         -> "PCData=" ^ String.escaped d
+  | Xml.Element (tag, _, _) ->
+      "Element=" ^ String.escaped tag
+  | Xml.PCData d ->
+      "PCData=" ^ String.escaped d
 
 type response =
-  | Success of Xml.xml list (** normal result *)
-  | Failure of string * (string list) (** failure/ exception in high-level code *)
-  | Fault of (int32 * string) (** error in the XMLRPC handling *)
-  | Raw of Xml.xml list (** Skipping the status *)
+  | Success of Xml.xml list  (** normal result *)
+  | Failure of string * string list
+      (** failure/ exception in high-level code *)
+  | Fault of (int32 * string)  (** error in the XMLRPC handling *)
+  | Raw of Xml.xml list  (** Skipping the status *)
 
 module ToString = struct
   let int64 = Int64.to_string
+
   let double = Printf.sprintf "%0.16g"
+
   let string x = x
 end
 
 module FromString = struct
   let int64 = Int64.of_string
+
   let double = float_of_string
+
   let string x = x
 end
 
 module To = struct
   let pcdata string = Xml.PCData string
 
-  let box tag vs = Xml.Element(tag, [], vs)
+  let box tag vs = Xml.Element (tag, [], vs)
 
   let value v = box "value" [v]
 
@@ -59,61 +67,69 @@ module To = struct
 
   let boolean b = value (box "boolean" [pcdata (if b then "1" else "0")])
 
-  let datetime s = value (box "dateTime.iso8601" [pcdata (Xapi_stdext_date.Date.to_string s)])
+  let datetime s =
+    value (box "dateTime.iso8601" [pcdata (Xapi_stdext_date.Date.to_string s)])
 
   let double x =
-    let txt = match classify_float x with
-      | FP_nan -> "NaN"
-      | FP_infinite -> "NaN"
-      | _ -> Printf.sprintf "%0.16g" x in
+    let txt =
+      match classify_float x with
+      | FP_nan ->
+          "NaN"
+      | FP_infinite ->
+          "NaN"
+      | _ ->
+          Printf.sprintf "%0.16g" x
+    in
     value (box "double" [pcdata txt])
 
   let int n = value (box "i4" [pcdata (Int32.to_string n)])
 
   let methodCall name params =
     box "methodCall"
-      [box "methodName" [pcdata name];
-       box "params" (List.map (fun param -> box "param" [param]) params)]
+      [
+        box "methodName" [pcdata name]
+      ; box "params" (List.map (fun param -> box "param" [param]) params)
+      ]
 
-  let string = function
-      "" -> box "value" []
-    | string -> value (pcdata string)
+  let string = function "" -> box "value" [] | string -> value (pcdata string)
 
   let structure fields =
-    value (box "struct" (List.map (fun (k, v) -> box "member" [name k; v]) fields))
+    value
+      (box "struct" (List.map (fun (k, v) -> box "member" [name k; v]) fields))
 
   (* let fault n s =
-    let faultCode = box "member" [name "faultCode"; int n] in
-    let faultString = box "member" [name "faultString"; string s] in
-    box "fault" [box "struct" [faultCode; faultString]] *)
+     let faultCode = box "member" [name "faultCode"; int n] in
+     let faultString = box "member" [name "faultString"; string s] in
+     box "fault" [box "struct" [faultCode; faultString]] *)
 
-  let success (v: Xml.xml) =
-    structure [ "Status", string "Success";
-                "Value", v ]
+  let success (v : Xml.xml) =
+    structure [("Status", string "Success"); ("Value", v)]
 
   let error code params =
-    let arr = string code :: (List.map string params) in
-    structure [ "Status", string "Failure";
-                "ErrorDescription", (array arr) ]
+    let arr = string code :: List.map string params in
+    structure [("Status", string "Failure"); ("ErrorDescription", array arr)]
 
   let methodResponse response =
     box "methodResponse"
-      [match response with
-       | Success [] ->
-         let result = success (string "") in
-         box "params" [ box "param" [ result ] ]
-       | Success [param] ->
-         let result = success param in
-         box "params" [ box "param" [ result ] ]
-       | Failure(code, params) ->
-         let result = error code params in
-         box "params" [ box "param" [ result ] ]
-       | Fault(n, s) ->
-         box "fault" [structure ["faultCode", int n;
-                                 "faultString", string s]]
-       | Raw [param] ->
-         box "params" [ box "param" [param]]
-       | _ -> failwith "To.methodResponse"
+      [
+        ( match response with
+        | Success [] ->
+            let result = success (string "") in
+            box "params" [box "param" [result]]
+        | Success [param] ->
+            let result = success param in
+            box "params" [box "param" [result]]
+        | Failure (code, params) ->
+            let result = error code params in
+            box "params" [box "param" [result]]
+        | Fault (n, s) ->
+            box "fault"
+              [structure [("faultCode", int n); ("faultString", string s)]]
+        | Raw [param] ->
+            box "params" [box "param" [param]]
+        | _ ->
+            failwith "To.methodResponse"
+        )
       ]
 end
 
@@ -121,42 +137,64 @@ module From = struct
   let id x = x
 
   let pcdata f = function
-    | Xml.PCData string -> f string
-    | xml -> rtte "pcdata" xml
+    | Xml.PCData string ->
+        f string
+    | xml ->
+        rtte "pcdata" xml
 
   let unbox ok f = function
-    | Xml.Element(s, [], data) when List.mem s ok -> f data
-    | xml -> rtte (Printf.sprintf "unbox: %s should contain '%s'" (pretty_print xml) (List.hd ok)) xml
+    | Xml.Element (s, [], data) when List.mem s ok ->
+        f data
+    | xml ->
+        rtte
+          (Printf.sprintf "unbox: %s should contain '%s'" (pretty_print xml)
+             (List.hd ok))
+          xml
 
   let singleton ok f xml =
-    unbox ok (function [x] -> f x | y -> rtte (Printf.sprintf "singleton: {%s} should be the singleton {%s}" (String.concat ", " (List.map pretty_print y)) (List.hd ok)) xml) xml
+    unbox ok
+      (function
+        | [x] ->
+            f x
+        | y ->
+            rtte
+              (Printf.sprintf "singleton: {%s} should be the singleton {%s}"
+                 (String.concat ", " (List.map pretty_print y))
+                 (List.hd ok))
+              xml)
+      xml
 
   let pair ok f1 f2 xml =
-    unbox ok (function [v1; v2] -> f1 v1, f2 v2 | _ -> rtte "pair " xml) xml
+    unbox ok (function [v1; v2] -> (f1 v1, f2 v2) | _ -> rtte "pair " xml) xml
 
   let value f xml = singleton ["value"] f xml
 
   (* <name> is only ever used inside a <struct><member>
      CA-20001: it is possible for <name> to be blank *)
-  let name f xml = unbox ["name"]
+  let name f xml =
+    unbox ["name"]
       (function
-        | [ Xml.PCData str ] -> f str
-        | [ ] ->
-          debug "encountered <name/> within a <structure>";
-          f ""
-        | _ -> rtte "From.name: should contain PCData" xml
-      ) xml
+        | [Xml.PCData str] ->
+            f str
+        | [] ->
+            debug "encountered <name/> within a <structure>" ;
+            f ""
+        | _ ->
+            rtte "From.name: should contain PCData" xml)
+      xml
 
   (* let check expected xml got =
-    if got <> expected then rtte ("check " ^ expected) xml *)
+     if got <> expected then rtte ("check " ^ expected) xml *)
 
   let nil = value (unbox ["nil"] (fun _ -> ()))
 
   let array f = value (singleton ["array"] (unbox ["data"] (List.map f)))
 
-  let boolean = value (singleton ["boolean"] ((<>) (Xml.PCData "0")))
+  let boolean = value (singleton ["boolean"] (( <> ) (Xml.PCData "0")))
 
-  let datetime x = Xapi_stdext_date.Date.of_string (value (singleton ["dateTime.iso8601"] (pcdata id)) x)
+  let datetime x =
+    Xapi_stdext_date.Date.of_string
+      (value (singleton ["dateTime.iso8601"] (pcdata id)) x)
 
   let double = value (singleton ["double"] (pcdata float_of_string))
 
@@ -169,44 +207,56 @@ module From = struct
       xml
 
   let string = function
-    | Xml.Element("value", [], [Xml.PCData s])                  -> s
-    | Xml.Element("value", [], [Xml.Element("string", [], [])])
-    | Xml.Element("value", [], [])                              -> ""
-    | xml                                                       -> value (singleton ["string"] (pcdata id)) xml
+    | Xml.Element ("value", [], [Xml.PCData s]) ->
+        s
+    | Xml.Element ("value", [], [Xml.Element ("string", [], [])])
+    | Xml.Element ("value", [], []) ->
+        ""
+    | xml ->
+        value (singleton ["string"] (pcdata id)) xml
 
   let structure : Xml.xml -> (string * Xml.xml) list =
-    singleton ["value"] (unbox ["struct"] (List.map (pair ["member"] (name id) id)))
+    singleton ["value"]
+      (unbox ["struct"] (List.map (pair ["member"] (name id) id)))
 
-  let success =
-    unbox ["params"] (List.map (singleton ["param"] id))
+  let success = unbox ["params"] (List.map (singleton ["param"] id))
 
   let status xml =
     let bindings = structure xml in
-    try match string (List.assoc "Status" bindings) with
-      | "Success" -> Success [ List.assoc "Value" bindings ]
-      | "Failure" -> begin
-          match array id (List.assoc "ErrorDescription" bindings) with
-          | [] -> rtte "Empty array of error strings" (Xml.PCData "")
-          | code::strings ->
+    try
+      match string (List.assoc "Status" bindings) with
+      | "Success" ->
+          Success [List.assoc "Value" bindings]
+      | "Failure" -> (
+        match array id (List.assoc "ErrorDescription" bindings) with
+        | [] ->
+            rtte "Empty array of error strings" (Xml.PCData "")
+        | code :: strings ->
             Failure (string code, List.map string strings)
-        end
-      | _ -> raise Not_found
+      )
+      | _ ->
+          raise Not_found
     with Not_found -> rtte "Status" xml
 
   let fault _f =
     let aux m =
-      int (List.assoc "faultCode" m), string (List.assoc "faultString" m) in
+      (int (List.assoc "faultCode" m), string (List.assoc "faultString" m))
+    in
     singleton ["fault"] (fun xml -> aux (structure xml))
 
   let methodResponse xml =
     singleton ["methodResponse"]
       (function
-        | Xml.Element("params", _, _) as xml -> begin match success xml with
-            | [ xml ] -> status xml
-            | _ -> rtte "Expected single return value (struct status)" xml
-          end
-        | Xml.Element("fault", _, _) as xml ->
-          Fault (fault id xml)
-        | xml -> rtte "response" xml)
+        | Xml.Element ("params", _, _) as xml -> (
+          match success xml with
+          | [xml] ->
+              status xml
+          | _ ->
+              rtte "Expected single return value (struct status)" xml
+        )
+        | Xml.Element ("fault", _, _) as xml ->
+            Fault (fault id xml)
+        | xml ->
+            rtte "response" xml)
       xml
 end

--- a/http-svr/xMLRPC.mli
+++ b/http-svr/xMLRPC.mli
@@ -22,16 +22,19 @@ type xmlrpc = Xml.xml
 
 (** An XML-RPC response: *)
 type response =
-  | Success of xmlrpc list           (** normal result *)
-  | Failure of string * (string list) (** failure/ exception in high-level code *)
-  | Fault of (int32 * string)         (** error in the XMLRPC handling *)
+  | Success of xmlrpc list  (** normal result *)
+  | Failure of string * string list
+      (** failure/ exception in high-level code *)
+  | Fault of (int32 * string)  (** error in the XMLRPC handling *)
   | Raw of xmlrpc list
 
 (** Functions to marshal some ocaml values to strings, suitable for
     keys in XMLRPC structs *)
 module ToString : sig
   val int64 : int64 -> string
+
   val double : float -> string
+
   val string : string -> string
 end
 
@@ -39,78 +42,80 @@ end
     keys in XMLRPC structs *)
 module FromString : sig
   val int64 : string -> int64
+
   val double : string -> float
+
   val string : string -> string
 end
 
 (** Functions to marshal OCaml values to our subset of XML-RPC. *)
 module To : sig
-  (** Marshal a nil value *)
   val nil : unit -> xmlrpc
+  (** Marshal a nil value *)
 
-  (** Marshal a homogeneous array. *)
   val array : xmlrpc list -> xmlrpc
+  (** Marshal a homogeneous array. *)
 
-  (** Marshal a boolean. *)
   val boolean : bool -> xmlrpc
+  (** Marshal a boolean. *)
 
-  (** Marshal a date-time. *)
   val datetime : Xapi_stdext_date.Date.iso8601 -> xmlrpc
+  (** Marshal a date-time. *)
 
-  (** Marshal a double. *)
   val double : float -> xmlrpc
+  (** Marshal a double. *)
 
-  (** Marshal a int. *)
   val int : int32 -> xmlrpc
+  (** Marshal a int. *)
 
-  (** Marshal a method call. *)
   val methodCall : string -> xmlrpc list -> xmlrpc
+  (** Marshal a method call. *)
 
-  (** Marshal a string. *)
   val string : string -> xmlrpc
+  (** Marshal a string. *)
 
-  (** Marshal a struct. *)
   val structure : (string * xmlrpc) list -> xmlrpc
+  (** Marshal a struct. *)
 
-  (** Marshal a method response. *)
   val methodResponse : response -> xmlrpc
-
+  (** Marshal a method response. *)
 end
 
 (** Higher-order functions to marshal values from our subset of XML-RPC. *)
 module From : sig
-  (** Parse a homogeneous array, applying f to the XML in element. *)
   val array : (xmlrpc -> 'a) -> xmlrpc -> 'a list
+  (** Parse a homogeneous array, applying f to the XML in element. *)
 
   val id : 'a -> 'a
+
   val pcdata : (string -> 'a) -> xmlrpc -> 'a
+
   val value : (xmlrpc -> 'a) -> xmlrpc -> 'a
 
-  (** Parse a nil (XMLRPC extension) *)
   val nil : xmlrpc -> unit
+  (** Parse a nil (XMLRPC extension) *)
 
-  (** Parse a boolean. *)
   val boolean : xmlrpc -> bool
+  (** Parse a boolean. *)
 
-  (** Parse a date-time. *)
   val datetime : xmlrpc -> Xapi_stdext_date.Date.iso8601
+  (** Parse a date-time. *)
 
-  (** Parse a double. *)
   val double : xmlrpc -> float
+  (** Parse a double. *)
 
-  (** Parse a int. *)
   val int : xmlrpc -> int32
+  (** Parse a int. *)
 
-  (** Parse a method call. *)
   val methodCall : xmlrpc -> string * xmlrpc list
+  (** Parse a method call. *)
 
-  (** Parse a string. *)
   val string : xmlrpc -> string
+  (** Parse a string. *)
 
-  (** Parse a struct. *)
   val structure : xmlrpc -> (string * xmlrpc) list
+  (** Parse a struct. *)
 
-  (** Parse a method response. *)
   val methodResponse : xmlrpc -> response
-
+  (** Parse a method response. *)
 end

--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -259,7 +259,7 @@ module SSL = struct
   type t = {
       use_fork_exec_helper: bool
     ; use_stunnel_cache: bool
-    ; verify_cert: Stunnel.config option
+    ; verify_cert: Stunnel.verification_config option
     ; task_id: string option
   }
 

--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -16,81 +16,100 @@ module Mutex = Xapi_stdext_threads.Threadext.Mutex
 module Unixext = Xapi_stdext_unix.Unixext
 
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
+
 open Safe_resources
 
-module D = Debug.Make(struct let name = "xmlrpc_client" end)
+module D = Debug.Make (struct let name = "xmlrpc_client" end)
+
 open D
 
-module E = Debug.Make(struct let name = "mscgen" end)
+module E = Debug.Make (struct let name = "mscgen" end)
 
 let () = Debug.disable ~level:Syslog.Debug "mscgen"
 
 module Internal = struct
-  let set_stunnelpid_callback : (string option -> int -> unit) option ref = ref None
-  let unset_stunnelpid_callback : (string option -> int -> unit) option ref = ref None
+  let set_stunnelpid_callback : (string option -> int -> unit) option ref =
+    ref None
+
+  let unset_stunnelpid_callback : (string option -> int -> unit) option ref =
+    ref None
+
   let destination_is_ok : (string -> bool) option ref = ref None
 end
 
 let user_agent = "xen-api-libs/1.0"
 
 let connect ?session_id ?task_id ?subtask_of path =
-  let arg str = Option.fold ~none:[] ~some:(fun x -> [ str, x ]) in
-  let cookie = arg "session_id" session_id @ (arg "task_id" task_id) @ (arg "subtask_of" subtask_of) in
-  Http.Request.make ~user_agent ~version:"1.0" ~keep_alive:true ~cookie ?subtask_of
-    Http.Connect path
+  let arg str = Option.fold ~none:[] ~some:(fun x -> [(str, x)]) in
+  let cookie =
+    arg "session_id" session_id
+    @ arg "task_id" task_id
+    @ arg "subtask_of" subtask_of
+  in
+  Http.Request.make ~user_agent ~version:"1.0" ~keep_alive:true ~cookie
+    ?subtask_of Http.Connect path
 
-let xmlrpc ?frame ?version ?keep_alive ?task_id ?cookie ?length ?auth ?subtask_of ?query ?body path =
-  let headers = Option.map (fun x -> [ Http.Hdr.task_id, x ]) task_id in
-  Http.Request.make ~user_agent ?frame ?version ?keep_alive ?cookie ?headers ?length ?auth ?subtask_of ?query ?body
-    Http.Post path
+let xmlrpc ?frame ?version ?keep_alive ?task_id ?cookie ?length ?auth
+    ?subtask_of ?query ?body path =
+  let headers = Option.map (fun x -> [(Http.Hdr.task_id, x)]) task_id in
+  Http.Request.make ~user_agent ?frame ?version ?keep_alive ?cookie ?headers
+    ?length ?auth ?subtask_of ?query ?body Http.Post path
 
 (** Thrown when ECONNRESET is caught which suggests the remote crashed or restarted *)
 exception Connection_reset
 
-module StunnelDebug=Debug.Make(struct let name="stunnel" end)
+module StunnelDebug = Debug.Make (struct let name = "stunnel" end)
+
 let write_to_log x = StunnelDebug.debug "%s" (Astring.String.trim x)
 
 (** Return true if this fd is connected to an HTTP server by sending an XMLRPC request
     for an unknown method and checking we get a matching MESSAGE_METHOD_UNKNOWN.
     This is used to prevent us accidentally trying to reuse a connection which has been
     closed or left in some other inconsistent state. *)
-let check_reusable_inner (x: Unixfd.t) =
+let check_reusable_inner (x : Unixfd.t) =
   let msg_name = "system.isAlive" in
   let msg_uuid = Uuidm.to_string (Uuidm.create `V4) in
   (* This is for backward compatability *)
   let msg_func = Printf.sprintf "%s:%s" msg_name msg_uuid in
-  let msg_param = [ XMLRPC.To.string msg_uuid ] in
+  let msg_param = [XMLRPC.To.string msg_uuid] in
   let xml = Xml.to_string (XMLRPC.To.methodCall msg_func msg_param) in
   let http = xmlrpc ~version:"1.1" ~keep_alive:true ~body:xml "/" in
-
   try
-    Http_client.rpc Unixfd.(!x) http
+    Http_client.rpc
+      Unixfd.(!x)
+      http
       (fun response _ ->
-         match response.Http.Response.content_length with
-         | Some len ->
-           let len = Int64.to_int len in
-           let tmp = Bytes.make len 'X' in
-           let buf = Buf_io.of_fd Unixfd.(!x) in
-           Buf_io.really_input buf tmp 0 len;
-           let tmp = Bytes.unsafe_to_string tmp in
-           begin match XMLRPC.From.methodResponse (Xml.parse_string tmp) with
-             | XMLRPC.Failure("MESSAGE_METHOD_UNKNOWN", [ param ])
-               when param = msg_func ->
-               (* This must be the server pre-dates system.isAlive *)
-               true
-             | XMLRPC.Success param when param = msg_param ->
-               (* This must be the new server withs system.isAlive *)
-               true
-             | _ ->
-               StunnelDebug.debug "check_reusable: unexpected response: connection not reusable: %s" tmp;
-               false
-           end
-         | None ->
-           StunnelDebug.debug "check_reusable: no content-length from known-invalid URI: connection not reusable";
-           false
-      )
+        match response.Http.Response.content_length with
+        | Some len -> (
+            let len = Int64.to_int len in
+            let tmp = Bytes.make len 'X' in
+            let buf = Buf_io.of_fd Unixfd.(!x) in
+            Buf_io.really_input buf tmp 0 len ;
+            let tmp = Bytes.unsafe_to_string tmp in
+            match XMLRPC.From.methodResponse (Xml.parse_string tmp) with
+            | XMLRPC.Failure ("MESSAGE_METHOD_UNKNOWN", [param])
+              when param = msg_func ->
+                (* This must be the server pre-dates system.isAlive *)
+                true
+            | XMLRPC.Success param when param = msg_param ->
+                (* This must be the new server withs system.isAlive *)
+                true
+            | _ ->
+                StunnelDebug.debug
+                  "check_reusable: unexpected response: connection not \
+                   reusable: %s"
+                  tmp ;
+                false
+          )
+        | None ->
+            StunnelDebug.debug
+              "check_reusable: no content-length from known-invalid URI: \
+               connection not reusable" ;
+            false)
   with exn ->
-    StunnelDebug.debug "check_reusable: caught exception %s; assuming not reusable" (Printexc.to_string exn);
+    StunnelDebug.debug
+      "check_reusable: caught exception %s; assuming not reusable"
+      (Printexc.to_string exn) ;
     false
 
 (** Thrown when repeated attempts to connect an stunnel to a remote host and check
@@ -100,15 +119,19 @@ exception Stunnel_connection_failed
 let get_new_stunnel_id =
   let counter = ref 0 in
   let m = Mutex.create () in
-  fun () -> Mutex.execute m (fun () -> incr counter; !counter)
+  fun () -> Mutex.execute m (fun () -> incr counter ; !counter)
 
 let watchdog_scheduler = Scheduler.make ()
 
 let run_watchdog timeout (fire_fn : unit -> unit) f =
   let fired = ref (Some false) in
-  let handle = Scheduler.one_shot watchdog_scheduler Scheduler.(Delta timeout) "watchdog timeout" @@ fun () ->
-    fired := None;
-    fire_fn ();
+  let handle =
+    Scheduler.one_shot watchdog_scheduler
+      Scheduler.(Delta timeout)
+      "watchdog timeout"
+    @@ fun () ->
+    fired := None ;
+    fire_fn () ;
     fired := Some true
   in
   let cancel_watchdog () = Scheduler.cancel watchdog_scheduler handle in
@@ -116,114 +139,141 @@ let run_watchdog timeout (fire_fn : unit -> unit) f =
   f cancel_watchdog get_fired
 
 let watchdog timeout pid f =
-   (run_watchdog
-      timeout
-      (fun () ->
-         StunnelDebug.warn "Watchdog fired: killing pid: %d" pid;
-         Unix.kill pid Sys.sigterm)
-      (fun cancel_watchdog get_fired ->
-         let result = try Some (f ()) with _ -> None in
-         cancel_watchdog ();
-         match get_fired (), result with
-         | Some true, _ ->
-           (* Watchdog fired, stunnel is killed. Not reusable *)
-           false
-         | Some false, None ->
-           (* Watchdog didn't fire, but f () raised an exception. Not reusable *)
-           false
-         | Some false, Some x ->
-           (* Watchdog didn't fire and we got a result from f() - return that result *)
-           x
-         | None, _ ->
-           (* fire_fn raised an exception (!) - Not reusable *)
-           false))
+  run_watchdog timeout
+    (fun () ->
+      StunnelDebug.warn "Watchdog fired: killing pid: %d" pid ;
+      Unix.kill pid Sys.sigterm)
+    (fun cancel_watchdog get_fired ->
+      let result = try Some (f ()) with _ -> None in
+      cancel_watchdog () ;
+      match (get_fired (), result) with
+      | Some true, _ ->
+          (* Watchdog fired, stunnel is killed. Not reusable *)
+          false
+      | Some false, None ->
+          (* Watchdog didn't fire, but f () raised an exception. Not reusable *)
+          false
+      | Some false, Some x ->
+          (* Watchdog didn't fire and we got a result from f() - return that result *)
+          x
+      | None, _ ->
+          (* fire_fn raised an exception (!) - Not reusable *)
+          false)
 
-let check_reusable x pid =
-  watchdog 30 pid (fun () -> check_reusable_inner x)
+let check_reusable x pid = watchdog 30 pid (fun () -> check_reusable_inner x)
 
 let assert_dest_is_ok host =
   (* Double check whether we _should_ be able to talk to this host *)
   let dest_is_ok =
-    match !Internal.destination_is_ok with
-    | Some f -> f host
-    | None -> true (* No check function set: assume it's OK *)
+    match !Internal.destination_is_ok with Some f -> f host | None -> true
+    (* No check function set: assume it's OK *)
   in
-  if not dest_is_ok then begin
-    StunnelDebug.error "Destination host has been marked as offline. Aborting";
+  if not dest_is_ok then (
+    StunnelDebug.error "Destination host has been marked as offline. Aborting" ;
     raise Stunnel_connection_failed
-  end
+  )
 
 (** Returns an stunnel, either from the persistent cache or a fresh one which
     has been checked out and guaranteed to work. *)
-let with_reusable_stunnel ?use_fork_exec_helper ?write_to_log ?verify_cert host port f =
+let with_reusable_stunnel ?use_fork_exec_helper ?write_to_log ?verify_cert host
+    port f =
   (* 1. First check if there is a suitable stunnel in the cache. *)
   let verify_cert = Stunnel.must_verify_cert verify_cert in
   let rec loop () =
-    match Stunnel_cache.with_remove host port verify_cert @@ fun x ->
-      if check_reusable x.Stunnel.fd (Stunnel.getpid x.Stunnel.pid)
-      then Ok (f x)
-      else begin
-        StunnelDebug.debug "get_reusable_stunnel: Found non-reusable stunnel in the cache. disconnecting from %s:%d" host port;
-        Stunnel.disconnect x;
+    match
+      Stunnel_cache.with_remove host port verify_cert @@ fun x ->
+      if check_reusable x.Stunnel.fd (Stunnel.getpid x.Stunnel.pid) then
+        Ok (f x)
+      else (
+        StunnelDebug.debug
+          "get_reusable_stunnel: Found non-reusable stunnel in the cache. \
+           disconnecting from %s:%d"
+          host port ;
+        Stunnel.disconnect x ;
         Error ()
-      end
+      )
     with
-    | Some (Ok r) -> r (* got result *)
-
+    | Some (Ok r) ->
+        r (* got result *)
     | Some (Error ()) ->
-      (* found in cache, but not reusable, keep trying until no stunnels
-         for this host in cache *)
-      loop ()
-
-    | None ->
-      StunnelDebug.debug "get_reusable_stunnel: stunnel cache is empty; creating a fresh connection to %s:%d" host port;
-      (* 2. Create a fresh connection and make sure it works *)
-      let max_attempts = 10 in
-      let delay = 10. in (* seconds *)
-      let attempt_number = ref 0 in
-      let result = ref None in
-      while !result = None && (!attempt_number < max_attempts) do
-        incr attempt_number;
-        try
-          let unique_id = get_new_stunnel_id () in
-          Stunnel.with_connect ~unique_id ?use_fork_exec_helper ?write_to_log ~verify_cert host port @@ fun x ->
-          if check_reusable x.Stunnel.fd (Stunnel.getpid x.Stunnel.pid)
-          then result := Some (try Ok (f x) with e -> Backtrace.is_important e; Error e)
-          else begin
-            assert_dest_is_ok host;
-            StunnelDebug.error "get_reusable_stunnel: fresh stunnel failed reusable check; delaying %.2f seconds before reconnecting to %s:%d (attempt %d / %d)" delay host port !attempt_number max_attempts;
-            Thread.delay delay;
-            Stunnel.disconnect x;
-          end
-        with e ->
-          assert_dest_is_ok host;
-          StunnelDebug.error "get_reusable_stunnel: fresh stunnel connection failed with exception: %s: delaying %.2f seconds before reconnecting to %s:%d (attempt %d / %d)" (Printexc.to_string e) delay host port !attempt_number max_attempts;
-          Thread.delay delay;
-      done;
-      match !result with
-      | Some (Ok r) -> r
-      | Some (Error e) -> raise e
-      | None ->
-        StunnelDebug.error "get_reusable_stunnel: failed to acquire a working stunnel to connect to %s:%d" host port;
-        raise Stunnel_connection_failed
-  in loop ()
+        (* found in cache, but not reusable, keep trying until no stunnels
+           for this host in cache *)
+        loop ()
+    | None -> (
+        StunnelDebug.debug
+          "get_reusable_stunnel: stunnel cache is empty; creating a fresh \
+           connection to %s:%d"
+          host port ;
+        (* 2. Create a fresh connection and make sure it works *)
+        let max_attempts = 10 in
+        let delay = 10. in
+        (* seconds *)
+        let attempt_number = ref 0 in
+        let result = ref None in
+        while !result = None && !attempt_number < max_attempts do
+          incr attempt_number ;
+          try
+            let unique_id = get_new_stunnel_id () in
+            Stunnel.with_connect ~unique_id ?use_fork_exec_helper ?write_to_log
+              ~verify_cert host port
+            @@ fun x ->
+            if check_reusable x.Stunnel.fd (Stunnel.getpid x.Stunnel.pid) then
+              result :=
+                Some
+                  (try Ok (f x) with e -> Backtrace.is_important e ; Error e)
+            else (
+              assert_dest_is_ok host ;
+              StunnelDebug.error
+                "get_reusable_stunnel: fresh stunnel failed reusable check; \
+                 delaying %.2f seconds before reconnecting to %s:%d (attempt \
+                 %d / %d)"
+                delay host port !attempt_number max_attempts ;
+              Thread.delay delay ;
+              Stunnel.disconnect x
+            )
+          with e ->
+            assert_dest_is_ok host ;
+            StunnelDebug.error
+              "get_reusable_stunnel: fresh stunnel connection failed with \
+               exception: %s: delaying %.2f seconds before reconnecting to \
+               %s:%d (attempt %d / %d)"
+              (Printexc.to_string e) delay host port !attempt_number
+              max_attempts ;
+            Thread.delay delay
+        done ;
+        match !result with
+        | Some (Ok r) ->
+            r
+        | Some (Error e) ->
+            raise e
+        | None ->
+            StunnelDebug.error
+              "get_reusable_stunnel: failed to acquire a working stunnel to \
+               connect to %s:%d"
+              host port ;
+            raise Stunnel_connection_failed
+      )
+  in
+  loop ()
 
 module SSL = struct
   type t = {
-    use_fork_exec_helper: bool;
-    use_stunnel_cache: bool;
-    verify_cert: bool option;
-    task_id: string option
+      use_fork_exec_helper: bool
+    ; use_stunnel_cache: bool
+    ; verify_cert: bool option
+    ; task_id: string option
   }
-  let make ?(use_fork_exec_helper=true) ?(use_stunnel_cache=false) ?(verify_cert) ?task_id () = {
-    use_fork_exec_helper = use_fork_exec_helper;
-    use_stunnel_cache = use_stunnel_cache;
-    verify_cert = verify_cert;
-    task_id = task_id
-  }
-  let to_string (x: t) =
-    Printf.sprintf "{ use_fork_exec_helper = %b; use_stunnel_cache = %b; verify_cert = %s; task_id = %s }"
-      x.use_fork_exec_helper x.use_stunnel_cache (Option.fold ~none:"None" ~some:(fun x -> string_of_bool x) x.verify_cert)
+
+  let make ?(use_fork_exec_helper = true) ?(use_stunnel_cache = false)
+      ?verify_cert ?task_id () =
+    {use_fork_exec_helper; use_stunnel_cache; verify_cert; task_id}
+
+  let to_string (x : t) =
+    Printf.sprintf
+      "{ use_fork_exec_helper = %b; use_stunnel_cache = %b; verify_cert = %s; \
+       task_id = %s }"
+      x.use_fork_exec_helper x.use_stunnel_cache
+      (Option.fold ~none:"None" ~some:(fun x -> string_of_bool x) x.verify_cert)
       (Option.fold ~none:"None" ~some:(fun x -> "Some " ^ x) x.task_id)
 end
 
@@ -233,157 +283,185 @@ type transport =
   | SSL of SSL.t * string * int
 
 let string_of_transport = function
-  | Unix x -> Printf.sprintf "Unix %s" x
-  | TCP (host, port) -> Printf.sprintf "TCP %s:%d" host port
-  | SSL (ssl, host, port) -> Printf.sprintf "SSL %s:%d %s" host port (SSL.to_string ssl)
+  | Unix x ->
+      Printf.sprintf "Unix %s" x
+  | TCP (host, port) ->
+      Printf.sprintf "TCP %s:%d" host port
+  | SSL (ssl, host, port) ->
+      Printf.sprintf "SSL %s:%d %s" host port (SSL.to_string ssl)
 
 let transport_of_url (scheme, _) =
   let open Http.Url in
   match scheme with
-  | File { path = path } -> Unix path
-  | Http ({ ssl = false; _ } as h) ->
-    let port = Option.value ~default:80 h.port in
-    TCP(h.host, port)
-  | Http ({ ssl = true; _ } as h) ->
-    let port = Option.value ~default:443 h.port in
-    SSL(SSL.make (), h.host, port)
+  | File {path} ->
+      Unix path
+  | Http ({ssl= false; _} as h) ->
+      let port = Option.value ~default:80 h.port in
+      TCP (h.host, port)
+  | Http ({ssl= true; _} as h) ->
+      let port = Option.value ~default:443 h.port in
+      SSL (SSL.make (), h.host, port)
 
 let with_transport transport f =
   match transport with
   | Unix path ->
-    let fd = Unixext.open_connection_unix_fd path in
-    finally
-      (fun () -> f fd)
-      (fun () -> Unix.close fd)
+      let fd = Unixext.open_connection_unix_fd path in
+      finally (fun () -> f fd) (fun () -> Unix.close fd)
   | TCP (host, port) ->
-    let fd = Unixext.open_connection_fd host port in
-    finally
-      (fun () ->
-         Unixext.set_tcp_nodelay fd true;
-         f fd)
-      (fun () -> Unix.close fd)
-  | SSL ({
-      SSL.use_fork_exec_helper = use_fork_exec_helper;
-      use_stunnel_cache = use_stunnel_cache;
-      verify_cert = verify_cert;
-      task_id = task_id}, host, port) ->
-    let st_proc' f =
-      if use_stunnel_cache
-      then with_reusable_stunnel ~use_fork_exec_helper ~write_to_log ?verify_cert host port f
-      else
-        let unique_id = get_new_stunnel_id () in
-        Stunnel.with_connect ~use_fork_exec_helper ~write_to_log ~unique_id ?verify_cert ~extended_diagnosis:true host port f in
-    st_proc' @@ fun st_proc ->
-    let s = st_proc.Stunnel.fd in
-    let s_pid = Stunnel.getpid st_proc.Stunnel.pid in
-    debug "stunnel pid: %d (cached = %b) connected to %s:%d" s_pid use_stunnel_cache host port;
-
-    (* Call the {,un}set_stunnelpid_callback hooks around the remote call *)
-    let with_recorded_stunnelpid task_opt s_pid f =
-      debug "with_recorded_stunnelpid task_opt=%s s_pid=%d" (Option.value ~default:"None" task_opt) s_pid;
-      begin
-        match !Internal.set_stunnelpid_callback with
-        | Some f -> f task_id s_pid
-        | _ -> ()
-      end;
-      finally f
+      let fd = Unixext.open_connection_fd host port in
+      finally
         (fun () ->
-           match !Internal.unset_stunnelpid_callback with
-           | Some f -> f task_id s_pid
-           | _ -> ()
-        ) in
-
-    with_recorded_stunnelpid task_id s_pid
-      (fun () ->
-         finally
-           (fun () ->
-              try
-                f Unixfd.(!s)
+          Unixext.set_tcp_nodelay fd true ;
+          f fd)
+        (fun () -> Unix.close fd)
+  | SSL
+      ( {SSL.use_fork_exec_helper; use_stunnel_cache; verify_cert; task_id}
+      , host
+      , port ) ->
+      let st_proc' f =
+        if use_stunnel_cache then
+          with_reusable_stunnel ~use_fork_exec_helper ~write_to_log ?verify_cert
+            host port f
+        else
+          let unique_id = get_new_stunnel_id () in
+          Stunnel.with_connect ~use_fork_exec_helper ~write_to_log ~unique_id
+            ?verify_cert ~extended_diagnosis:true host port f
+      in
+      st_proc' @@ fun st_proc ->
+      let s = st_proc.Stunnel.fd in
+      let s_pid = Stunnel.getpid st_proc.Stunnel.pid in
+      debug "stunnel pid: %d (cached = %b) connected to %s:%d" s_pid
+        use_stunnel_cache host port ;
+      (* Call the {,un}set_stunnelpid_callback hooks around the remote call *)
+      let with_recorded_stunnelpid task_opt s_pid f =
+        debug "with_recorded_stunnelpid task_opt=%s s_pid=%d"
+          (Option.value ~default:"None" task_opt)
+          s_pid ;
+        ( match !Internal.set_stunnelpid_callback with
+        | Some f ->
+            f task_id s_pid
+        | _ ->
+            ()
+        ) ;
+        finally f (fun () ->
+            match !Internal.unset_stunnelpid_callback with
+            | Some f ->
+                f task_id s_pid
+            | _ ->
+                ())
+      in
+      with_recorded_stunnelpid task_id s_pid (fun () ->
+          finally
+            (fun () ->
+              try f Unixfd.(!s)
               with e ->
-                warn "stunnel pid: %d caught %s" s_pid (Printexc.to_string e);
-                if e = Connection_reset && not use_stunnel_cache
-                then if Sys.file_exists st_proc.Stunnel.logfile then
-                    Stunnel.diagnose_failure st_proc;
+                warn "stunnel pid: %d caught %s" s_pid (Printexc.to_string e) ;
+                if e = Connection_reset && not use_stunnel_cache then
+                  if Sys.file_exists st_proc.Stunnel.logfile then
+                    Stunnel.diagnose_failure st_proc ;
                 raise e)
-           (fun () ->
-              if use_stunnel_cache
-              then begin
-                Stunnel_cache.add st_proc;
-                debug "stunnel pid: %d (cached = %b) returned stunnel to cache" s_pid use_stunnel_cache;
-              end else
-                begin
-                  Unix.unlink st_proc.Stunnel.logfile;
-                  Stunnel.disconnect st_proc
-                end
-           )
-      )
+            (fun () ->
+              if use_stunnel_cache then (
+                Stunnel_cache.add st_proc ;
+                debug "stunnel pid: %d (cached = %b) returned stunnel to cache"
+                  s_pid use_stunnel_cache
+              ) else (
+                Unix.unlink st_proc.Stunnel.logfile ;
+                Stunnel.disconnect st_proc
+              )))
 
 let with_http request f s =
-  try
-    Http_client.rpc s request (fun response s -> f (response, s))
-  with Unix.Unix_error(Unix.ECONNRESET, _, _) -> raise Connection_reset
+  try Http_client.rpc s request (fun response s -> f (response, s))
+  with Unix.Unix_error (Unix.ECONNRESET, _, _) -> raise Connection_reset
 
 let curry2 f (a, b) = f a b
 
 module type FORMAT = sig
   type response
-  val response_of_string: string -> response
-  val response_of_file_descr: Unix.file_descr -> response
+
+  val response_of_string : string -> response
+
+  val response_of_file_descr : Unix.file_descr -> response
+
   type request
-  val request_to_string: request -> string
-  val request_to_short_string: request -> string
+
+  val request_to_string : request -> string
+
+  val request_to_short_string : request -> string
 end
 
 module XML = struct
   type response = Xml.xml
+
   let response_of_string = Xml.parse_string
+
   let response_of_file_descr fd = Xml.parse_in (Unix.in_channel_of_descr fd)
+
   type request = Xml.xml
+
   let request_to_string = Xml.to_string
-  let request_to_short_string = fun _ -> "(XML)"
+
+  let request_to_short_string _ = "(XML)"
 end
 
 module XMLRPC = struct
   type response = Rpc.response
+
   let response_of_string x = Xmlrpc.response_of_string x
-  let response_of_file_descr fd = Xmlrpc.response_of_in_channel (Unix.in_channel_of_descr fd)
+
+  let response_of_file_descr fd =
+    Xmlrpc.response_of_in_channel (Unix.in_channel_of_descr fd)
+
   type request = Rpc.call
+
   let request_to_string x = Xmlrpc.string_of_call x
+
   let request_to_short_string x = x.Rpc.name
 end
 
 module JSONRPC = struct
   type response = Rpc.response
+
   let response_of_string x = Jsonrpc.response_of_string x
-  let response_of_file_descr fd = Jsonrpc.response_of_in_channel (Unix.in_channel_of_descr fd)
+
+  let response_of_file_descr fd =
+    Jsonrpc.response_of_in_channel (Unix.in_channel_of_descr fd)
+
   type request = Rpc.call
+
   let request_to_string x = Jsonrpc.string_of_call x
+
   let request_to_short_string x = x.Rpc.name
 end
 
-module Protocol = functor(F: FORMAT) -> struct
-  (** Take an optional content_length and task_id together with a socket
+module Protocol =
+functor
+  (F : FORMAT)
+  ->
+  struct
+    (** Take an optional content_length and task_id together with a socket
       		and return the XMLRPC response as an XML document *)
-  let read_response r s =
-    try
-      match r.Http.Response.content_length with
-      | Some l when (Int64.to_int l) <= Sys.max_string_length ->
-        F.response_of_string (Xapi_stdext_unix.Unixext.really_read_string s (Int64.to_int l))
-      | Some _ | None -> F.response_of_file_descr s
-    with
-    | Unix.Unix_error(Unix.ECONNRESET, _, _) -> raise Connection_reset
+    let read_response r s =
+      try
+        match r.Http.Response.content_length with
+        | Some l when Int64.to_int l <= Sys.max_string_length ->
+            F.response_of_string
+              (Xapi_stdext_unix.Unixext.really_read_string s (Int64.to_int l))
+        | Some _ | None ->
+            F.response_of_file_descr s
+      with Unix.Unix_error (Unix.ECONNRESET, _, _) -> raise Connection_reset
 
-  let rpc ?(srcstr="unset") ?(dststr="unset") ~transport ~http req =
-    (* Caution: req can contain sensitive information such as passwords in its parameters,
-       		 * so we should not log the parameters or a string representation of the whole thing.
-       		 * The name should be safe though, e.g. req.Rpc.name when F is XMLRPC. *)
-    E.debug "%s=>%s [label=\"%s\"];" srcstr dststr (F.request_to_short_string req) ;
-    let body = F.request_to_string req in
-    let http = { http with Http.Request.body = Some body } in
-    with_transport transport (with_http http (curry2 read_response))
-end
+    let rpc ?(srcstr = "unset") ?(dststr = "unset") ~transport ~http req =
+      (* Caution: req can contain sensitive information such as passwords in its parameters,
+         		 * so we should not log the parameters or a string representation of the whole thing.
+         		 * The name should be safe though, e.g. req.Rpc.name when F is XMLRPC. *)
+      E.debug "%s=>%s [label=\"%s\"];" srcstr dststr
+        (F.request_to_short_string req) ;
+      let body = F.request_to_string req in
+      let http = {http with Http.Request.body= Some body} in
+      with_transport transport (with_http http (curry2 read_response))
+  end
 
-module XML_protocol = Protocol(XML)
-module XMLRPC_protocol = Protocol(XMLRPC)
-module JSONRPC_protocol = Protocol(JSONRPC)
-
+module XML_protocol = Protocol (XML)
+module XMLRPC_protocol = Protocol (XMLRPC)
+module JSONRPC_protocol = Protocol (JSONRPC)

--- a/http-svr/xmlrpc_client.mli
+++ b/http-svr/xmlrpc_client.mli
@@ -24,87 +24,128 @@ module SSL : sig
   (** A desired SSL configuration *)
   type t
 
+  val make :
+       ?use_fork_exec_helper:bool
+    -> ?use_stunnel_cache:bool
+    -> ?verify_cert:bool
+    -> ?task_id:string
+    -> unit
+    -> t
   (** [make] is used to create a type [t] *)
-  val make : ?use_fork_exec_helper:bool ->
-    ?use_stunnel_cache:bool ->
-    ?verify_cert:bool ->
-    ?task_id:string -> unit -> t
 end
 
 (** Understood low-level transport types *)
 type transport =
-  | Unix of string              (** Unix domain socket *)
-  | TCP of string * int         (** Plain TCP/IP with a host, port *)
-  | SSL of SSL.t * string * int (** SSL over TCP/IP with a host, port *)
+  | Unix of string  (** Unix domain socket *)
+  | TCP of string * int  (** Plain TCP/IP with a host, port *)
+  | SSL of SSL.t * string * int  (** SSL over TCP/IP with a host, port *)
 
-(** [transport_of_url url] returns the transport associated with [url] *)
 val transport_of_url : Http.Url.t -> transport
+(** [transport_of_url url] returns the transport associated with [url] *)
 
-(** [string_of_transport t] returns a debug-friendly version of [t] *)
 val string_of_transport : transport -> string
+(** [string_of_transport t] returns a debug-friendly version of [t] *)
 
+val with_transport : transport -> (Unix.file_descr -> 'a) -> 'a
 (** [with_transport transport f] calls [f fd] with [fd] connected via
     	the requested [transport] *)
-val with_transport : transport -> (Unix.file_descr -> 'a) -> 'a
 
+val with_http :
+     Http.Request.t
+  -> (Http.Response.t * Unix.file_descr -> 'a)
+  -> Unix.file_descr
+  -> 'a
 (** [with_http request f] calls [f (r, fd)] where [r] is the HTTP response
     received after sending HTTP [request] and [fd] is still connected to
     	the client. *)
-val with_http : Http.Request.t -> (Http.Response.t * Unix.file_descr -> 'a) -> Unix.file_descr -> 'a
 
+val xmlrpc :
+     ?frame:bool
+  -> ?version:string
+  -> ?keep_alive:bool
+  -> ?task_id:string
+  -> ?cookie:(string * string) list
+  -> ?length:int64
+  -> ?auth:Http.authorization
+  -> ?subtask_of:string
+  -> ?query:(string * string) list
+  -> ?body:string
+  -> string
+  -> Http.Request.t
 (** Returns an HTTP.Request.t representing an XMLRPC request *)
-val xmlrpc: ?frame:bool -> ?version:string -> ?keep_alive:bool -> ?task_id:string -> ?cookie:(string*string) list -> ?length:int64 -> ?auth:Http.authorization -> ?subtask_of:string -> ?query:((string * string) list) -> ?body:string -> string -> Http.Request.t
 
+val connect :
+     ?session_id:string
+  -> ?task_id:string
+  -> ?subtask_of:string
+  -> string
+  -> Http.Request.t
 (** Returns an HTTP.Request.t representing an HTTP CONNECT *)
-val connect: ?session_id:string -> ?task_id:string -> ?subtask_of:string -> string -> Http.Request.t
 
 module XML_protocol : sig
   (** Functions for handling HTTP/XML (not necessarily XMLRPC) *)
 
+  val read_response : Http.Response.t -> Unix.file_descr -> Xml.xml
   (** [read_response r fd] returns the XML from [fd] given
       		HTTP request [r] *)
-  val read_response : Http.Response.t -> Unix.file_descr -> Xml.xml
 
+  val rpc :
+       ?srcstr:string
+    -> ?dststr:string
+    -> transport:transport
+    -> http:Http.Request.t
+    -> Xml.xml
+    -> Xml.xml
   (** [rpc transport http xml] sends [xml] and returns the result *)
-  val rpc : ?srcstr:string -> ?dststr:string -> transport:transport -> http:Http.Request.t -> Xml.xml -> Xml.xml
 end
 
 module XMLRPC_protocol : sig
   (** Functions for handling HTTP/XML via rpc-light *)
 
+  val read_response : Http.Response.t -> Unix.file_descr -> Rpc.response
   (** [read_response r fd] returns the response from [fd] given
       		HTTP request [r] *)
-  val read_response : Http.Response.t -> Unix.file_descr -> Rpc.response
 
+  val rpc :
+       ?srcstr:string
+    -> ?dststr:string
+    -> transport:transport
+    -> http:Http.Request.t
+    -> Rpc.call
+    -> Rpc.response
   (** [rpc transport http call] sends [call] and returns the result *)
-  val rpc : ?srcstr:string -> ?dststr:string -> transport:transport -> http:Http.Request.t -> Rpc.call -> Rpc.response
 end
 
 module JSONRPC_protocol : sig
   (** Functions for handling HTTP/JSONRPC *)
 
-  (** [read_response r fd] returns the response from [fd] given HTTP request [r] *)
   val read_response : Http.Response.t -> Unix.file_descr -> Rpc.response
+  (** [read_response r fd] returns the response from [fd] given HTTP request [r] *)
 
+  val rpc :
+       ?srcstr:string
+    -> ?dststr:string
+    -> transport:transport
+    -> http:Http.Request.t
+    -> Rpc.call
+    -> Rpc.response
   (** [rpc transport http call] sends [call] and returns the result *)
-  val rpc : ?srcstr:string -> ?dststr:string -> transport:transport -> http:Http.Request.t -> Rpc.call -> Rpc.response
 end
 
 module Internal : sig
   (** Internal functions should not be used by clients directly *)
 
+  val set_stunnelpid_callback : (string option -> int -> unit) option ref
   (** When invoking an XMLRPC call over HTTPS via stunnel, this callback
       		is called to allow us to store the association between a task and an
       		stunnel pid *)
-  val set_stunnelpid_callback : (string option -> int -> unit) option ref
 
+  val unset_stunnelpid_callback : (string option -> int -> unit) option ref
   (** After invoking an XMLRPC call over HTTPS via stunnel, this callback
       		is called to allow us to forget the association between a task and an
       		stunnel pid *)
-  val unset_stunnelpid_callback : (string option -> int -> unit) option ref
 
+  val destination_is_ok : (string -> bool) option ref
   (** Callback to check whether a destination address is still OK. Only called after
       a failed attempt to talk to the destination *)
-  val destination_is_ok : (string -> bool) option ref
-
 end

--- a/http-svr/xmlrpc_client.mli
+++ b/http-svr/xmlrpc_client.mli
@@ -27,7 +27,7 @@ module SSL : sig
   val make :
        ?use_fork_exec_helper:bool
     -> ?use_stunnel_cache:bool
-    -> ?verify_cert:bool
+    -> verify_cert:Stunnel.config option
     -> ?task_id:string
     -> unit
     -> t

--- a/http-svr/xmlrpc_client.mli
+++ b/http-svr/xmlrpc_client.mli
@@ -27,7 +27,7 @@ module SSL : sig
   val make :
        ?use_fork_exec_helper:bool
     -> ?use_stunnel_cache:bool
-    -> verify_cert:Stunnel.config option
+    -> verify_cert:Stunnel.verification_config option
     -> ?task_id:string
     -> unit
     -> t

--- a/pciutil/pciutil.ml
+++ b/pciutil/pciutil.ml
@@ -17,50 +17,55 @@
 
 (* defaults, if we can't find better information: *)
 let unknown_vendor vendor = Some (Printf.sprintf "Unknown vendor %s" vendor)
+
 let unknown_device device = Some (Printf.sprintf "Unknown device %s" device)
 
 let parse_from file vendor device =
   let open Xapi_stdext_unix in
-  let vendor_str = ref (unknown_vendor vendor) and device_str = ref (unknown_device device) in
+  let vendor_str = ref (unknown_vendor vendor)
+  and device_str = ref (unknown_device device) in
   (* CA-26771: As we parse the file we keep track of the current vendor.
-     	   When we find a device match we only accept it if it's from the right vendor; it doesn't make 
+     	   When we find a device match we only accept it if it's from the right vendor; it doesn't make
      	   sense to pair vendor 2's device with vendor 1. *)
   let current_xvendor = ref "" in
-  Unixext.readfile_line (fun line ->
-      if line = "" || line.[0] = '#' ||
-         (line.[0] = '\t' && line.[1] = '\t') then
-        (* ignore subvendors/subdevices, blank lines and comments *)
+  Unixext.readfile_line
+    (fun line ->
+      if line = "" || line.[0] = '#' || (line.[0] = '\t' && line.[1] = '\t')
+      then (* ignore subvendors/subdevices, blank lines and comments *)
         ()
-      else (
-        if line.[0] = '\t' then (
+      else if line.[0] = '\t' then (
+        if
           (* device *)
           (* ignore if this is some other vendor's device *)
-          if !current_xvendor = vendor then (
-            let xdevice = String.sub line 1 4 in
-            if xdevice = device then (
-              device_str := Some (String.sub line 7 (String.length line - 7));
-              (* abort reading, we found what we want *)
-              raise Unixext.Break
-            )
+          !current_xvendor = vendor
+        then
+          let xdevice = String.sub line 1 4 in
+          if xdevice = device then (
+            device_str := Some (String.sub line 7 (String.length line - 7)) ;
+            (* abort reading, we found what we want *)
+            raise Unixext.Break
           )
-        ) else (
-          (* vendor *)
-          current_xvendor := String.sub line 0 4;
-          if !current_xvendor = vendor then
-            vendor_str := Some (String.sub line 6 (String.length line - 6))
-        )
-      )
-    ) file;
-  !vendor_str, !device_str
+      ) else (
+        (* vendor *)
+        current_xvendor := String.sub line 0 4 ;
+        if !current_xvendor = vendor then
+          vendor_str := Some (String.sub line 6 (String.length line - 6))
+      ))
+    file ;
+  (!vendor_str, !device_str)
 
 let parse vendor device =
   let access_list l perms =
-    List.filter (fun path ->
-        (try Unix.access path perms; true with _ -> false)) l
+    List.filter
+      (fun path -> try Unix.access path perms ; true with _ -> false)
+      l
   in
   try
     (* is that the correct path ? *)
-    let l = access_list [ "/usr/share/hwdata/pci.ids"; "/usr/share/misc/pci.ids" ] [ Unix.R_OK ] in
+    let l =
+      access_list
+        ["/usr/share/hwdata/pci.ids"; "/usr/share/misc/pci.ids"]
+        [Unix.R_OK]
+    in
     parse_from (List.hd l) vendor device
-  with _
-    -> unknown_vendor vendor, unknown_device device
+  with _ -> (unknown_vendor vendor, unknown_device device)

--- a/pciutil/pciutil.mli
+++ b/pciutil/pciutil.mli
@@ -15,4 +15,5 @@
 (** Utility to parse PCI id *)
 
 val parse_from : string -> string -> string -> string option * string option
+
 val parse : string -> string -> string option * string option

--- a/sexpr/sExpr.ml
+++ b/sexpr/sExpr.ml
@@ -12,15 +12,18 @@
  * GNU Lesser General Public License for more details.
  *)
 type t =
-    Node of t list
+  | Node of t list
   | Symbol of string
   | String of string
   | WeirdString of string * string
 
 let unescape_buf buf s =
   let aux esc = function
-      '\\' when not esc -> true
-    | c -> Buffer.add_char buf c; false in
+    | '\\' when not esc ->
+        true
+    | c ->
+        Buffer.add_char buf c ; false
+  in
   if Astring.String.fold_left aux false s then
     Buffer.add_char buf '\\'
 
@@ -34,20 +37,26 @@ let unescape_buf buf s =
 let escape s =
   let open Astring in
   let escaped = Buffer.create (String.length s + 10) in
-  String.iter (fun c ->
-      let c' = match c with
-        | '\\' -> "\\\\"
-        | '"'  -> "\\\""
-        | '\'' -> "\\\'"
-        |  _   -> Astring.String.of_char c
+  String.iter
+    (fun c ->
+      let c' =
+        match c with
+        | '\\' ->
+            "\\\\"
+        | '"' ->
+            "\\\""
+        | '\'' ->
+            "\\\'"
+        | _ ->
+            Astring.String.of_char c
       in
-      Buffer.add_string escaped c') s;
+      Buffer.add_string escaped c')
+    s ;
   Buffer.contents escaped
 
 let unescape s =
   let buf = Buffer.create (String.length s) in
-  unescape_buf buf s;
-  Buffer.contents buf
+  unescape_buf buf s ; Buffer.contents buf
 
 let mkstring x = String (unescape x)
 
@@ -56,54 +65,59 @@ let string_of sexpr =
   let rec __string_of_rec x =
     match x with
     | Node l ->
-      Buffer.add_char buf '(';
-      begin match l with
-        | []     -> ()
-        | [ a ]  -> __string_of_rec a
-        | [ a ; b ] -> __string_of_rec a; Buffer.add_char buf ' '; __string_of_rec b
+        Buffer.add_char buf '(' ;
+        ( match l with
+        | [] ->
+            ()
+        | [a] ->
+            __string_of_rec a
+        | [a; b] ->
+            __string_of_rec a ; Buffer.add_char buf ' ' ; __string_of_rec b
         | a :: l ->
-          __string_of_rec a;
-          List.iter (fun i -> Buffer.add_char buf ' '; __string_of_rec i) l;
-      end;
-      Buffer.add_char buf ')';
-    | Symbol s | String s | WeirdString(_, s) ->
-      Buffer.add_string buf "\'";
-      Buffer.add_string buf (escape s);
-      Buffer.add_string buf "\'";
+            __string_of_rec a ;
+            List.iter (fun i -> Buffer.add_char buf ' ' ; __string_of_rec i) l
+        ) ;
+        Buffer.add_char buf ')'
+    | Symbol s | String s | WeirdString (_, s) ->
+        Buffer.add_string buf "\'" ;
+        Buffer.add_string buf (escape s) ;
+        Buffer.add_string buf "\'"
   in
-  __string_of_rec sexpr;
-  Buffer.contents buf
+  __string_of_rec sexpr ; Buffer.contents buf
 
-let weird_of_string x = 
+let weird_of_string x =
   let random_chars = "abcdefghijklmnopqrstuvwxyz" in
-  let randchar () = String.sub random_chars (Random.int (String.length random_chars)) 1 in
-  (* true if the parent string contains child as a substring, starting the 
+  let randchar () =
+    String.sub random_chars (Random.int (String.length random_chars)) 1
+  in
+  (* true if the parent string contains child as a substring, starting the
      search forward from offset *)
-  let rec has_substring parent offset child = 
-    (String.length parent - offset >= (String.length child)) &&
-    ((String.sub parent offset (String.length child) = child)
-     || has_substring parent (offset + 1) child) in
-  let rec find delim = 
-    if has_substring x 0 delim then (find (delim ^ (randchar ()))) else delim in
-  WeirdString(find "xxx", x)
+  let rec has_substring parent offset child =
+    String.length parent - offset >= String.length child
+    && (String.sub parent offset (String.length child) = child
+       || has_substring parent (offset + 1) child
+       )
+  in
+  let rec find delim =
+    if has_substring x 0 delim then find (delim ^ randchar ()) else delim
+  in
+  WeirdString (find "xxx", x)
 
 let rec output_fmt ff = function
   | Node list ->
-    let rec aux ?(first=true) = function
-        [] -> ()
-      | h::t when first ->
-        output_fmt ff h;
-        aux ~first:false t
-      | h::t ->
-        Format.fprintf ff "@;<1 2>%a" output_fmt h;
-        aux ~first t in
-    Format.fprintf ff "@[(";
-    aux list;
-    Format.fprintf ff ")@]"
-  | Symbol s
-  | String s
-  | WeirdString(_, s) ->
-    Format.fprintf ff "\"%s\"" (escape s)
+      let rec aux ?(first = true) = function
+        | [] ->
+            ()
+        | h :: t when first ->
+            output_fmt ff h ; aux ~first:false t
+        | h :: t ->
+            Format.fprintf ff "@;<1 2>%a" output_fmt h ;
+            aux ~first t
+      in
+      Format.fprintf ff "@[(" ; aux list ; Format.fprintf ff ")@]"
+  | Symbol s | String s | WeirdString (_, s) ->
+      Format.fprintf ff "\"%s\"" (escape s)
+
 (*
   | Symbol s ->
       Format.fprintf ff "%s" s

--- a/sexpr/sExpr.mli
+++ b/sexpr/sExpr.mli
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 type t =
-    Node of t list
+  | Node of t list
   | Symbol of string
   | String of string
   | WeirdString of string * string

--- a/sexpr/sExprLexer.mli
+++ b/sexpr/sExprLexer.mli
@@ -1,4 +1,7 @@
 val line : int ref
+
 val __ocaml_lex_tables : Lexing.lex_tables
+
 val token : Lexing.lexbuf -> SExprParser.token
+
 val __ocaml_lex_token_rec : Lexing.lexbuf -> int -> SExprParser.token

--- a/sexpr/sExpr_TS.ml
+++ b/sexpr/sExpr_TS.ml
@@ -15,7 +15,7 @@
 let lock = Mutex.create ()
 
 let of_string s =
-  Xapi_stdext_threads.Threadext.Mutex.execute lock
-    (fun () -> SExprParser.expr SExprLexer.token (Lexing.from_string s))
+  Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+      SExprParser.expr SExprLexer.token (Lexing.from_string s))
 
 let string_of = SExpr.string_of

--- a/sexpr/sexprpp.ml
+++ b/sexpr/sexprpp.ml
@@ -13,19 +13,18 @@
  *)
 let lexer = Lexing.from_channel stdin
 
-let _ = match Sys.argv with
+let _ =
+  match Sys.argv with
   | [|_; "-nofmt"|] ->
-    let start_time = Sys.time() in
-    let sexpr = SExprParser.expr SExprLexer.token lexer in
-    let parse_time = Sys.time() in
-    let s = SExpr.string_of sexpr in
-    let print_time = Sys.time() in
-    Printf.fprintf stderr
-      "Parse time: %f\nPrint time: %f\n%!"
-      (parse_time -. start_time) (print_time -. parse_time);
-    print_endline s
+      let start_time = Sys.time () in
+      let sexpr = SExprParser.expr SExprLexer.token lexer in
+      let parse_time = Sys.time () in
+      let s = SExpr.string_of sexpr in
+      let print_time = Sys.time () in
+      Printf.fprintf stderr "Parse time: %f\nPrint time: %f\n%!"
+        (parse_time -. start_time) (print_time -. parse_time) ;
+      print_endline s
   | _ ->
-    let sexpr = SExprParser.expr SExprLexer.token lexer in
-    let ff = Format.formatter_of_out_channel stdout in
-    SExpr.output_fmt ff sexpr;
-    Format.fprintf ff "@."
+      let sexpr = SExprParser.expr SExprLexer.token lexer in
+      let ff = Format.formatter_of_out_channel stdout in
+      SExpr.output_fmt ff sexpr ; Format.fprintf ff "@."

--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -13,7 +13,7 @@
  *)
 (* Copyright (C) 2007 XenSource Inc *)
 
-module D=Debug.Make(struct let name="stunnel" end)
+module D = Debug.Make (struct let name = "stunnel" end)
 
 open Printf
 open Xapi_stdext_pervasives.Pervasiveext
@@ -21,15 +21,19 @@ open Xapi_stdext_unix
 open Safe_resources
 
 exception Stunnel_binary_missing
+
 exception Stunnel_error of string
+
 exception Stunnel_verify_error of string
 
 let certificates_bundle_path = "/etc/stunnel/xapi-stunnel-ca-bundle.pem"
 
 let crl_path = "/etc/stunnel/crls"
+
 let verify_certificates_ctrl = "/var/xapi/verify_certificates"
 
 let cached_stunnel_path = ref None
+
 let stunnel_logger = ref ignore
 
 let timeoutidle = ref None
@@ -37,26 +41,32 @@ let timeoutidle = ref None
 let init_stunnel_path () =
   try cached_stunnel_path := Some (Unix.getenv "XE_STUNNEL")
   with Not_found ->
-      let choices = [
-        "/opt/xensource/libexec/stunnel/stunnel";
-        "/usr/sbin/stunnel4";
-        "/usr/sbin/stunnel";
-        "/usr/bin/stunnel4";
-        "/usr/bin/stunnel";
-      ] in
-      let rec choose l =
-        match l with
-        | [] -> raise Stunnel_binary_missing
-        | p::ps ->
-          try Unix.access p [Unix.X_OK]; p
-          with _ -> choose ps
-      in
-      let path = choose choices in
-      cached_stunnel_path := Some path
+    let choices =
+      [
+        "/opt/xensource/libexec/stunnel/stunnel"
+      ; "/usr/sbin/stunnel4"
+      ; "/usr/sbin/stunnel"
+      ; "/usr/bin/stunnel4"
+      ; "/usr/bin/stunnel"
+      ]
+    in
+    let rec choose l =
+      match l with
+      | [] ->
+          raise Stunnel_binary_missing
+      | p :: ps -> (
+        try
+          Unix.access p [Unix.X_OK] ;
+          p
+        with _ -> choose ps
+      )
+    in
+    let path = choose choices in
+    cached_stunnel_path := Some path
 
 let stunnel_path () =
   if Option.is_none !cached_stunnel_path then
-    init_stunnel_path ();
+    init_stunnel_path () ;
   Option.get !cached_stunnel_path
 
 module Unsafe = struct
@@ -65,21 +75,24 @@ module Unsafe = struct
   (* Low-level (unsafe) function which forks, runs a 'pre_exec' function and
      	 then executes some other binary. It makes sure to catch any exception thrown by
      	 exec* so that we don't end up with two ocaml processes. *)
-  let fork_and_exec ?(pre_exec=fun () -> ()) ?env (cmdline: string list) =
+  let fork_and_exec ?(pre_exec = fun () -> ()) ?env (cmdline : string list) =
     let args = Array.of_list cmdline in
     let argv0 = List.hd cmdline in
     let pid = Unix.fork () in
-    if pid = 0 then begin
+    if pid = 0 then
       try
-        pre_exec ();
+        pre_exec () ;
         (* CA-18955: xapi now runs with priority -3. We then set his sons priority to 0. *)
-        ignore_int (Unix.nice (-(Unix.nice 0)));
-        ignore_int (Unix.setsid ());
+        ignore_int (Unix.nice (-Unix.nice 0)) ;
+        ignore_int (Unix.setsid ()) ;
         match env with
-        | None -> Unix.execv argv0 args
-        | Some env -> Unix.execve argv0 args env
+        | None ->
+            Unix.execv argv0 args
+        | Some env ->
+            Unix.execve argv0 args env
       with _ -> exit 1
-    end else pid
+    else
+      pid
 
   (* File descriptor operations to be performed after a fork.
    * These are all safe in the presence of threads *)
@@ -88,13 +101,15 @@ module Unsafe = struct
     | Close of Unix.file_descr
 
   let do_fd_operation = function
-    | Dup2(a, b) -> Unix.dup2 a b
-    | Close a -> Unix.close a
+    | Dup2 (a, b) ->
+        Unix.dup2 a b
+    | Close a ->
+        Unix.close a
 end
 
 type pid =
-  | StdFork of int (** we forked and exec'ed. This is the pid *)
-  | FEFork of Forkhelpers.pidty (** the forkhelpers module did it for us. *)
+  | StdFork of int  (** we forked and exec'ed. This is the pid *)
+  | FEFork of Forkhelpers.pidty  (** the forkhelpers module did it for us. *)
   | Nopid
 
 (* let string_of_pid = function
@@ -104,88 +119,124 @@ type pid =
 
 let getpid ty =
   match ty with
-  | StdFork pid -> pid
-  | FEFork pid -> Forkhelpers.getpid pid
-  | Nopid -> failwith "No pid!"
+  | StdFork pid ->
+      pid
+  | FEFork pid ->
+      Forkhelpers.getpid pid
+  | Nopid ->
+      failwith "No pid!"
 
-type t = { mutable pid: pid; fd: Unixfd.t; host: string; port: int; 
-           connected_time: float;
-           unique_id: int option;
-           mutable logfile: string;
-           verified: bool;
-         }
+type t = {
+    mutable pid: pid
+  ; fd: Unixfd.t
+  ; host: string
+  ; port: int
+  ; connected_time: float
+  ; unique_id: int option
+  ; mutable logfile: string
+  ; verified: bool
+}
 
 let config_file verify_cert extended_diagnosis host port =
   let is_fips =
-    Inventory.inventory_filename := "/etc/xensource-inventory";
-    try
-      bool_of_string (Inventory.lookup ~default:"false" "CC_PREPARATIONS")
+    Inventory.inventory_filename := "/etc/xensource-inventory" ;
+    try bool_of_string (Inventory.lookup ~default:"false" "CC_PREPARATIONS")
     with _ -> false
   in
-  String.concat "\n" @@ List.concat
-  [ [ "client=yes"
-    ; "foreground=yes"
-    ; "socket = r:TCP_NODELAY=1"
-    ; "socket = r:SO_KEEPALIVE=1"
-    ; "socket = a:SO_KEEPALIVE=1"
-    ; (match !timeoutidle with
-      None -> "" |
-      Some x -> Printf.sprintf "TIMEOUTidle = %d" x)
-    ; Printf.sprintf "connect=%s:%d" host port
-    ]
-  ; if is_fips then ["fips=yes"] else ["fips=no"]
-  ; if extended_diagnosis then ["debug=authpriv.7"] else ["debug=authpriv.5"]
-  ; [ "sslVersion = TLSv1.2"
-    ; "ciphers = " ^ Xcp_const.good_ciphersuites
-    ; "curve = secp384r1"
-    ]
-  ; if verify_cert then
-      [ ""
-      ; "# use SNI to request a specific cert. CAfile contains"
-      ; "# public certs of all hosts in the pool and must contain"
-      ; "# the cert of the server we connect to"
-      ; "sni = pool"
-      ; "verifyPeer=yes"
-      ; sprintf "CAfile=%s" certificates_bundle_path
-      ; (match Sys.readdir crl_path with
-         | [| |] -> ""
-         | _ -> sprintf "CRLpath=%s" crl_path
-         | exception _ -> "")
-      ]
-    else []
-    ; [""]
-  ]
+  String.concat "\n"
+  @@ List.concat
+       [
+         [
+           "client=yes"
+         ; "foreground=yes"
+         ; "socket = r:TCP_NODELAY=1"
+         ; "socket = r:SO_KEEPALIVE=1"
+         ; "socket = a:SO_KEEPALIVE=1"
+         ; ( match !timeoutidle with
+           | None ->
+               ""
+           | Some x ->
+               Printf.sprintf "TIMEOUTidle = %d" x
+           )
+         ; Printf.sprintf "connect=%s:%d" host port
+         ]
+       ; (if is_fips then ["fips=yes"] else ["fips=no"])
+       ; ( if extended_diagnosis then
+             ["debug=authpriv.7"]
+         else
+           ["debug=authpriv.5"]
+         )
+       ; [
+           "sslVersion = TLSv1.2"
+         ; "ciphers = " ^ Xcp_const.good_ciphersuites
+         ; "curve = secp384r1"
+         ]
+       ; ( if verify_cert then
+             [
+               ""
+             ; "# use SNI to request a specific cert. CAfile contains"
+             ; "# public certs of all hosts in the pool and must contain"
+             ; "# the cert of the server we connect to"
+             ; "sni = pool"
+             ; "verifyPeer=yes"
+             ; sprintf "CAfile=%s" certificates_bundle_path
+             ; ( match Sys.readdir crl_path with
+               | [||] ->
+                   ""
+               | _ ->
+                   sprintf "CRLpath=%s" crl_path
+               | exception _ ->
+                   ""
+               )
+             ]
+         else
+           []
+         )
+       ; [""]
+       ]
 
 let ignore_exn f x = try f x with _ -> ()
 
 let disconnect ?(wait = true) ?(force = false) x =
-  ignore_exn Unixfd.safe_close x.fd;
-
+  ignore_exn Unixfd.safe_close x.fd ;
   let do_disc waiter pid =
     let res =
       try waiter ()
-      with Unix.Unix_error (Unix.ECHILD, _, _) -> pid, Unix.WEXITED 0 in
+      with Unix.Unix_error (Unix.ECHILD, _, _) -> (pid, Unix.WEXITED 0)
+    in
     match res with
-    | 0, _ when force ->
-      (try Unix.kill pid Sys.sigkill
-       with Unix.Unix_error (Unix.ESRCH, _, _) ->())
-    | _ -> ()
+    | 0, _ when force -> (
+      try Unix.kill pid Sys.sigkill
+      with Unix.Unix_error (Unix.ESRCH, _, _) -> ()
+    )
+    | _ ->
+        ()
   in
-  (match x.pid with
+  ( match x.pid with
   | FEFork fpid ->
-    let pid_int = Forkhelpers.getpid fpid in
-    do_disc
-      (fun () ->
-         (if wait then Forkhelpers.waitpid
-          else Forkhelpers.waitpid_nohang) fpid)
-      pid_int
+      let pid_int = Forkhelpers.getpid fpid in
+      do_disc
+        (fun () ->
+          ( if wait then
+              Forkhelpers.waitpid
+          else
+            Forkhelpers.waitpid_nohang
+          )
+            fpid)
+        pid_int
   | StdFork pid ->
-    do_disc
-      (fun () ->
-         (if wait then Unix.waitpid []
-          else Unix.waitpid [Unix.WNOHANG]) pid)
-      pid
-  | Nopid -> ());
+      do_disc
+        (fun () ->
+          ( if wait then
+              Unix.waitpid []
+          else
+            Unix.waitpid [Unix.WNOHANG]
+          )
+            pid)
+        pid
+  | Nopid ->
+      ()
+  ) ;
   (* make disconnect idempotent, need to do it here,
      due to the recursive call *)
   x.pid <- Nopid
@@ -196,102 +247,133 @@ let disconnect ?(wait = true) ?(force = false) x =
    exception instead *)
 exception Stunnel_initialisation_failed
 
-
 (* Internal function which may throw Stunnel_initialisation_failed *)
 let with_attempt_one_connect ?unique_id ?(use_fork_exec_helper = true)
     ?(write_to_log = fun _ -> ()) verify_cert extended_diagnosis host port f =
   Unixfd.with_pipe () ~loc:__LOC__ @@ fun config_out config_in ->
   let config_out_uuid = Uuidm.to_string (Uuidm.create `V4) in
-      let config_out_fd = 
-    string_of_int (Unixext.int_of_file_descr Unixfd.(!config_out)) in
-  let fds_needed = [ Unixfd.(!config_out); Unix.stdin; Unix.stdout; Unix.stderr ] in
-  let configs = [config_out_uuid, Unixfd.(!config_out)] in
-  let args = ["-fd"; if use_fork_exec_helper then config_out_uuid else config_out_fd]
+  let config_out_fd =
+    string_of_int (Unixext.int_of_file_descr Unixfd.(!config_out))
+  in
+  let fds_needed =
+    [Unixfd.(!config_out); Unix.stdin; Unix.stdout; Unix.stderr]
+  in
+  let configs = [(config_out_uuid, Unixfd.(!config_out))] in
+  let args =
+    ["-fd"; (if use_fork_exec_helper then config_out_uuid else config_out_fd)]
   in
   Unixfd.with_socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 ~loc:__LOC__
   @@ fun data_in data_out ->
   (* Dereference just once to ensure we are consistent in t and config_file *)
   let t =
-    { pid = Nopid; fd = data_out; host = host; port = port;
-      connected_time = Unix.gettimeofday (); unique_id = unique_id;
-      logfile = ""; verified = verify_cert; } in
-  let result = Forkhelpers.with_logfile_fd "stunnel"
-      ~delete:(not extended_diagnosis)
+    {
+      pid= Nopid
+    ; fd= data_out
+    ; host
+    ; port
+    ; connected_time= Unix.gettimeofday ()
+    ; unique_id
+    ; logfile= ""
+    ; verified= verify_cert
+    }
+  in
+  let result =
+    Forkhelpers.with_logfile_fd "stunnel" ~delete:(not extended_diagnosis)
       (fun logfd ->
-         let path = stunnel_path() in
-         let fdops =
-           [ Unsafe.Dup2(Unixfd.(!data_in), Unix.stdin);
-             Unsafe.Dup2(Unixfd.(!data_in), Unix.stdout);
-             Unsafe.Dup2(logfd, Unix.stderr) ] in
-         t.pid <-
-           if use_fork_exec_helper then begin
-             FEFork(Forkhelpers.safe_close_and_exec
-                      (Some Unixfd.(!data_in)) (Some Unixfd.(!data_in)) (Some logfd) configs path args)
-           end else
-             StdFork(Unsafe.fork_and_exec
-                       ~pre_exec:(fun _ ->
-                           List.iter Unsafe.do_fd_operation fdops;
-                           Unixext.close_all_fds_except fds_needed) 
-                       (path::args));
-         Unixfd.safe_close config_out;
-         Unixfd.safe_close data_in;
-         let config = config_file verify_cert extended_diagnosis host port in
-         (* Catch the occasional initialisation failure of stunnel: *)
-         try
-           let len = String.length config in
-           let n = Unix.write Unixfd.(!config_in) (Bytes.of_string config) 0 len in
-           if n < len then raise Stunnel_initialisation_failed;
-           Unixfd.safe_close config_in
-                  with Unix.Unix_error(err, fn, arg) -> 
-           write_to_log (Printf.sprintf "Caught Unix.Unix_error(%s, %s, %s); raising Stunnel_initialisation_failed" (Unix.error_message err) fn arg);
-           raise Stunnel_initialisation_failed
-      ) in
+        let path = stunnel_path () in
+        let fdops =
+          [
+            Unsafe.Dup2 (Unixfd.(!data_in), Unix.stdin)
+          ; Unsafe.Dup2 (Unixfd.(!data_in), Unix.stdout)
+          ; Unsafe.Dup2 (logfd, Unix.stderr)
+          ]
+        in
+        t.pid <-
+          ( if use_fork_exec_helper then
+              FEFork
+                (Forkhelpers.safe_close_and_exec
+                   (Some Unixfd.(!data_in))
+                   (Some Unixfd.(!data_in))
+                   (Some logfd) configs path args)
+          else
+            StdFork
+              (Unsafe.fork_and_exec
+                 ~pre_exec:(fun _ ->
+                   List.iter Unsafe.do_fd_operation fdops ;
+                   Unixext.close_all_fds_except fds_needed)
+                 (path :: args))
+          ) ;
+        Unixfd.safe_close config_out ;
+        Unixfd.safe_close data_in ;
+        let config = config_file verify_cert extended_diagnosis host port in
+        (* Catch the occasional initialisation failure of stunnel: *)
+        try
+          let len = String.length config in
+          let n =
+            Unix.write Unixfd.(!config_in) (Bytes.of_string config) 0 len
+          in
+          if n < len then raise Stunnel_initialisation_failed ;
+          Unixfd.safe_close config_in
+        with Unix.Unix_error (err, fn, arg) ->
+          write_to_log
+            (Printf.sprintf
+               "Caught Unix.Unix_error(%s, %s, %s); raising \
+                Stunnel_initialisation_failed"
+               (Unix.error_message err) fn arg) ;
+          raise Stunnel_initialisation_failed)
+  in
   (* Tidy up any remaining unclosed fds *)
   match result with
-  | Forkhelpers.Success(log, _) ->
-    if extended_diagnosis then begin
-      write_to_log "stunnel start";
-      t.logfile <- log
-    end;
-    f t
-  | Forkhelpers.Failure(log, exn) ->
-    write_to_log ("stunnel abort: Log from stunnel: [" ^ log ^ "]");
-    disconnect t;
-    raise exn
+  | Forkhelpers.Success (log, _) ->
+      if extended_diagnosis then (
+        write_to_log "stunnel start" ;
+        t.logfile <- log
+      ) ;
+      f t
+  | Forkhelpers.Failure (log, exn) ->
+      write_to_log ("stunnel abort: Log from stunnel: [" ^ log ^ "]") ;
+      disconnect t ;
+      raise exn
 
 (** To cope with a slightly unreliable stunnel, attempt to retry to make
     the connection a number of times. *)
 let rec retry f = function
-  | 0 -> raise Stunnel_initialisation_failed
-  | n ->
+  | 0 ->
+      raise Stunnel_initialisation_failed
+  | n -> (
     try f ()
     with Stunnel_initialisation_failed ->
       (* Leave a few seconds between each attempt *)
-      ignore(Unix.select [] [] [] 3.);
+      ignore (Unix.select [] [] [] 3.) ;
       retry f (n - 1)
+  )
 
 let must_verify_cert verify_cert =
   match verify_cert with
-  | Some x -> x
-  | None -> Sys.file_exists verify_certificates_ctrl
+  | Some x ->
+      x
+  | None ->
+      Sys.file_exists verify_certificates_ctrl
 
 (** Establish a fresh stunnel to a (host, port)
     @param extended_diagnosis If true, the stunnel log file will not be
     deleted.  Instead, it is the caller's responsibility to delete it.  This
     allows the caller to use diagnose_failure below if stunnel fails.  *)
-let with_connect
-    ?unique_id
-    ?use_fork_exec_helper
-    ?write_to_log
-    ?verify_cert
-    ?(extended_diagnosis=false)
-    host
-    port f = 
+let with_connect ?unique_id ?use_fork_exec_helper ?write_to_log ?verify_cert
+    ?(extended_diagnosis = false) host port f =
   let _verify_cert = must_verify_cert verify_cert in
-  let _ = match write_to_log with
-    | Some logger -> stunnel_logger := logger
-    | None -> () in
-  retry (fun () -> with_attempt_one_connect ?unique_id ?use_fork_exec_helper ?write_to_log _verify_cert extended_diagnosis host port f) 5
+  let _ =
+    match write_to_log with
+    | Some logger ->
+        stunnel_logger := logger
+    | None ->
+        ()
+  in
+  retry
+    (fun () ->
+      with_attempt_one_connect ?unique_id ?use_fork_exec_helper ?write_to_log
+        _verify_cert extended_diagnosis host port f)
+    5
 
 let check_verify_error line =
   let sub_after i s =
@@ -299,20 +381,18 @@ let check_verify_error line =
     String.sub s i (len - i)
   in
   let split_1 c s =
-    match Astring.String.cut ~sep:c s with
-    | Some (x , _) -> x
-    | None -> s
+    match Astring.String.cut ~sep:c s with Some (x, _) -> x | None -> s
   in
   if Astring.String.is_infix ~affix:"VERIFY ERROR: " line then
     match Astring.String.find_sub ~sub:"error=" line with
     | Some e ->
-      raise
-        (Stunnel_verify_error
-           (split_1 ","
-              (sub_after (e + String.length "error=") line)))
+        raise
+          (Stunnel_verify_error
+             (split_1 "," (sub_after (e + String.length "error=") line)))
     | None ->
-      raise (Stunnel_verify_error "")
-  else ()
+        raise (Stunnel_verify_error "")
+  else
+    ()
 
 let check_error s line =
   if Astring.String.is_infix ~affix:line s then
@@ -320,13 +400,15 @@ let check_error s line =
 
 let diagnose_failure st_proc =
   let check_line line =
-    !stunnel_logger line;
-    check_verify_error line;
-    check_error "Connection refused" line;
-    check_error "No host resolved" line;
-    check_error "No route to host" line;
-    check_error "Invalid argument" line in
+    !stunnel_logger line ;
+    check_verify_error line ;
+    check_error "Connection refused" line ;
+    check_error "No host resolved" line ;
+    check_error "No route to host" line ;
+    check_error "Invalid argument" line
+  in
   Unixext.readfile_line check_line st_proc.logfile
+
 (* If we reach here the whole stunnel log should have been gone through
    (possibly printed/logged somewhere. No necessity to raise an exception,
    since when this function being called, there is usually some exception
@@ -337,14 +419,17 @@ let diagnose_failure st_proc =
 let test host port =
   let counter = ref 0 in
   while true do
-    with_connect ~write_to_log:print_endline host port disconnect;
-    incr counter;
-    if !counter mod 100 = 0 then (Printf.printf "Ran stunnel %d times\n" !counter; flush stdout)
+    with_connect ~write_to_log:print_endline host port disconnect ;
+    incr counter ;
+    if !counter mod 100 = 0 then (
+      Printf.printf "Ran stunnel %d times\n" !counter ;
+      flush stdout
+    )
   done
 
-let move_out_exn t = { t with fd = Safe.move_exn t.fd }
+let move_out_exn t = {t with fd= Safe.move_exn t.fd}
 
 let with_moved_exn t f =
-  Safe.within (Safe.move_exn t.fd) @@ fun fd -> f { t with fd }
+  Safe.within (Safe.move_exn t.fd) @@ fun fd -> f {t with fd}
 
 let safe_release t = disconnect ~wait:false ~force:true t

--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -124,7 +124,11 @@ let getpid ty =
 
 type verify = VerifyPeer | CheckHost
 
-type config = {sni: string option; verify: verify; cert_bundle_path: string}
+type verification_config = {
+    sni: string option
+  ; verify: verify
+  ; cert_bundle_path: string
+}
 
 type t = {
     mutable pid: pid
@@ -134,7 +138,7 @@ type t = {
   ; connected_time: float
   ; unique_id: int option
   ; mutable logfile: string
-  ; verified: config option
+  ; verified: verification_config option
 }
 
 let appliance =

--- a/stunnel/stunnel.mli
+++ b/stunnel/stunnel.mli
@@ -21,8 +21,6 @@ exception Stunnel_verify_error of string
 
 val crl_path : string
 
-val verify_certificates_ctrl : string
-
 val timeoutidle : int option ref
 
 type pid =
@@ -31,6 +29,10 @@ type pid =
   | Nopid
 
 val getpid : pid -> int
+
+type verify = VerifyPeer | CheckHost
+
+type config = {sni: string option; verify: verify; cert_bundle_path: string}
 
 (** Represents an active stunnel connection *)
 type t = {
@@ -42,14 +44,18 @@ type t = {
         (** time when the connection opened, for 'early retirement' *)
   ; unique_id: int option
   ; mutable logfile: string
-  ; verified: bool
+  ; verified: config option
 }
+
+val appliance : config
+
+val pool : config
 
 val with_connect :
      ?unique_id:int
   -> ?use_fork_exec_helper:bool
   -> ?write_to_log:(string -> unit)
-  -> ?verify_cert:bool
+  -> verify_cert:config option
   -> ?extended_diagnosis:bool
   -> string
   -> int
@@ -67,8 +73,6 @@ val disconnect : ?wait:bool -> ?force:bool -> t -> unit
 val diagnose_failure : t -> unit
 
 val test : string -> int -> unit
-
-val must_verify_cert : bool option -> bool
 
 val move_out_exn : t -> t
 

--- a/stunnel/stunnel.mli
+++ b/stunnel/stunnel.mli
@@ -32,7 +32,11 @@ val getpid : pid -> int
 
 type verify = VerifyPeer | CheckHost
 
-type config = {sni: string option; verify: verify; cert_bundle_path: string}
+type verification_config = {
+    sni: string option
+  ; verify: verify
+  ; cert_bundle_path: string
+}
 
 (** Represents an active stunnel connection *)
 type t = {
@@ -44,18 +48,18 @@ type t = {
         (** time when the connection opened, for 'early retirement' *)
   ; unique_id: int option
   ; mutable logfile: string
-  ; verified: config option
+  ; verified: verification_config option
 }
 
-val appliance : config
+val appliance : verification_config
 
-val pool : config
+val pool : verification_config
 
 val with_connect :
      ?unique_id:int
   -> ?use_fork_exec_helper:bool
   -> ?write_to_log:(string -> unit)
-  -> verify_cert:config option
+  -> verify_cert:verification_config option
   -> ?extended_diagnosis:bool
   -> string
   -> int

--- a/stunnel/stunnel.mli
+++ b/stunnel/stunnel.mli
@@ -11,9 +11,12 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
+
 (** Thrown if we can't find the stunnel binary in the prescribed location *)
 exception Stunnel_binary_missing
+
 exception Stunnel_error of string
+
 exception Stunnel_verify_error of string
 
 val crl_path : string
@@ -23,38 +26,43 @@ val verify_certificates_ctrl : string
 val timeoutidle : int option ref
 
 type pid =
-  | StdFork of int (** we forked and exec'ed. This is the pid *)
-  | FEFork of Forkhelpers.pidty (** the forkhelpers module did it for us. *)
+  | StdFork of int  (** we forked and exec'ed. This is the pid *)
+  | FEFork of Forkhelpers.pidty  (** the forkhelpers module did it for us. *)
   | Nopid
 
-val getpid: pid -> int
+val getpid : pid -> int
 
 (** Represents an active stunnel connection *)
-type t = { mutable pid: pid;
-           fd: Safe_resources.Unixfd.t;
-           host: string;
-           port: int;
-           connected_time: float; (** time when the connection opened, for 'early retirement' *)
-           unique_id: int option;
-           mutable logfile: string;
-           verified: bool;
-         }
+type t = {
+    mutable pid: pid
+  ; fd: Safe_resources.Unixfd.t
+  ; host: string
+  ; port: int
+  ; connected_time: float
+        (** time when the connection opened, for 'early retirement' *)
+  ; unique_id: int option
+  ; mutable logfile: string
+  ; verified: bool
+}
 
+val with_connect :
+     ?unique_id:int
+  -> ?use_fork_exec_helper:bool
+  -> ?write_to_log:(string -> unit)
+  -> ?verify_cert:bool
+  -> ?extended_diagnosis:bool
+  -> string
+  -> int
+  -> (t -> 'b)
+  -> 'b
 (** Connects via stunnel (optionally via an external 'fork/exec' helper) to
     a host and port.
     NOTE: this does not guarantee the connection to the remote server actually works.
     For server-side connections, use Xmlrpcclient.get_reusable_stunnel instead.
 *)
-val with_connect :
-  ?unique_id:int ->
-  ?use_fork_exec_helper:bool ->
-  ?write_to_log:(string -> unit) ->
-  ?verify_cert:bool ->
-  ?extended_diagnosis:bool ->
-  string -> int -> (t -> 'b) -> 'b
 
-(** Disconnects from stunnel and cleans up *)
 val disconnect : ?wait:bool -> ?force:bool -> t -> unit
+(** Disconnects from stunnel and cleans up *)
 
 val diagnose_failure : t -> unit
 
@@ -64,6 +72,6 @@ val must_verify_cert : bool option -> bool
 
 val move_out_exn : t -> t
 
-val with_moved_exn: t -> (t -> 'd) -> 'd
+val with_moved_exn : t -> (t -> 'd) -> 'd
 
-val safe_release: t -> unit
+val safe_release : t -> unit

--- a/stunnel/stunnel_cache.ml
+++ b/stunnel/stunnel_cache.ml
@@ -37,7 +37,11 @@ let ignore_log fmt = Printf.ksprintf (fun _ -> ()) fmt
 (* Use and overlay the definition from D. *)
 let debug = if debug_enabled then debug else ignore_log
 
-type endpoint = {host: string; port: int; verified: Stunnel.config option}
+type endpoint = {
+    host: string
+  ; port: int
+  ; verified: Stunnel.verification_config option
+}
 
 (* Need to limit the absolute number of stunnels as well as the maximum age *)
 let max_stunnel = 70

--- a/stunnel/stunnel_cache.ml
+++ b/stunnel/stunnel_cache.ml
@@ -22,26 +22,28 @@
 
 module Mutex = Xapi_stdext_threads.Threadext.Mutex
 
-module D=Debug.Make(struct let name="stunnel_cache" end)
+module D = Debug.Make (struct let name = "stunnel_cache" end)
+
 open D
 open Safe_resources
 
 (* Disable debug-level logging but leave higher-priority enabled.  It would be
  * better to handle this sort of configuration in the Debug module itself.
-*)
+ *)
 let debug_enabled = false
 
-let ignore_log fmt =
-  Printf.ksprintf (fun _ -> ()) fmt
+let ignore_log fmt = Printf.ksprintf (fun _ -> ()) fmt
 
 (* Use and overlay the definition from D. *)
 let debug = if debug_enabled then debug else ignore_log
 
-type endpoint = { host: string; port: int; verified: bool }
+type endpoint = {host: string; port: int; verified: bool}
 
 (* Need to limit the absolute number of stunnels as well as the maximum age *)
 let max_stunnel = 70
+
 let max_age = 180. *. 60. (* seconds *)
+
 let max_idle = 5. *. 60. (* seconds *)
 
 (* The add function adds the new stunnel before doing gc, so the cache *)
@@ -54,7 +56,7 @@ let index : (endpoint, int list) Hashtbl.t ref = ref (Hashtbl.create capacity)
 (** A mapping of stunnel unique IDs to donation times *)
 let times : (int, float) Hashtbl.t ref = ref (Hashtbl.create capacity)
 
-module Tbl = Table.Make(Stunnel)
+module Tbl = Table.Make (Stunnel)
 
 (** A mapping of stunnel unique ID to Stunnel.t *)
 let stunnels : int Tbl.t ref = ref (Tbl.create capacity)
@@ -65,146 +67,169 @@ let id_of_stunnel stunnel =
   Option.fold ~none:"unknown" ~some:string_of_int stunnel.Stunnel.unique_id
 
 let unlocked_gc () =
-  if debug_enabled then begin
-    let now = Unix.gettimeofday () in
-    let string_of_id id = 
-      let stunnel = Tbl.find !stunnels id in
-      Printf.sprintf "(id %s / idle %.2f age %.2f)" 
-        (id_of_stunnel stunnel)
-        (now -. (Hashtbl.find !times id))
-        (now -. stunnel.Stunnel.connected_time) in
-    let string_of_endpoint ep = Printf.sprintf "%s:%d" ep.host ep.port in
-    let string_of_index ep xs = Printf.sprintf "[ %s %s ]" (string_of_endpoint ep) (String.concat "; " (List.map string_of_id xs)) in
-    debug "Cache contents: %s" (Hashtbl.fold (fun ep xs acc -> string_of_index ep xs ^ " " ^ acc) !index "");
-  end;
-
+  ( if debug_enabled then
+      let now = Unix.gettimeofday () in
+      let string_of_id id =
+        let stunnel = Tbl.find !stunnels id in
+        Printf.sprintf "(id %s / idle %.2f age %.2f)" (id_of_stunnel stunnel)
+          (now -. Hashtbl.find !times id)
+          (now -. stunnel.Stunnel.connected_time)
+      in
+      let string_of_endpoint ep = Printf.sprintf "%s:%d" ep.host ep.port in
+      let string_of_index ep xs =
+        Printf.sprintf "[ %s %s ]" (string_of_endpoint ep)
+          (String.concat "; " (List.map string_of_id xs))
+      in
+      debug "Cache contents: %s"
+        (Hashtbl.fold
+           (fun ep xs acc -> string_of_index ep xs ^ " " ^ acc)
+           !index "")
+  ) ;
   (* Split a list at the given index to give a pair of lists.
    *  From Xapi_stdext_std.Listext *)
   let rec chop i l =
-    match i, l with
-    | 0, l -> [], l
-    | i, h :: t -> (fun (fr, ba) -> h :: fr, ba) (chop (i - 1) t)
-    | _ -> invalid_arg "chop"
+    match (i, l) with
+    | 0, l ->
+        ([], l)
+    | i, h :: t ->
+        (fun (fr, ba) -> (h :: fr, ba)) (chop (i - 1) t)
+    | _ ->
+        invalid_arg "chop"
   in
-
   let all_ids = Tbl.fold !stunnels (fun k _ acc -> k :: acc) [] in
-
   let to_gc = ref [] in
   (* Find the ones which are too old *)
   let now = Unix.gettimeofday () in
-  Tbl.iter !stunnels
-    (fun idx stunnel ->
-       let time = Hashtbl.find !times idx in
-       let idle = now -. time in
-       let age = now -. stunnel.Stunnel.connected_time in
-       if age > max_age then begin
-         debug "Expiring stunnel id %s; age (%.2f) > limit (%.2f)" (id_of_stunnel stunnel) age max_age;
-         to_gc := idx :: !to_gc
-       end else if idle > max_idle then begin
-         debug "Expiring stunnel id %s; idle (%.2f) > limit (%.2f)" (id_of_stunnel stunnel) age max_idle;
-         to_gc := idx :: !to_gc
-       end);
-  let num_remaining = List.length all_ids - (List.length !to_gc) in
-  if num_remaining > max_stunnel then begin
+  Tbl.iter !stunnels (fun idx stunnel ->
+      let time = Hashtbl.find !times idx in
+      let idle = now -. time in
+      let age = now -. stunnel.Stunnel.connected_time in
+      if age > max_age then (
+        debug "Expiring stunnel id %s; age (%.2f) > limit (%.2f)"
+          (id_of_stunnel stunnel) age max_age ;
+        to_gc := idx :: !to_gc
+      ) else if idle > max_idle then (
+        debug "Expiring stunnel id %s; idle (%.2f) > limit (%.2f)"
+          (id_of_stunnel stunnel) age max_idle ;
+        to_gc := idx :: !to_gc
+      )) ;
+  let num_remaining = List.length all_ids - List.length !to_gc in
+  if num_remaining > max_stunnel then (
     let times' = Hashtbl.fold (fun k v acc -> (k, v) :: acc) !times [] in
-    let times' = List.filter (fun (idx, _) -> not(List.mem idx !to_gc)) times' in
+    let times' =
+      List.filter (fun (idx, _) -> not (List.mem idx !to_gc)) times'
+    in
     (* Sort into descending order of donation time, ie youngest first *)
     let times' = List.sort (fun x y -> compare (fst y) (fst x)) times' in
     let _youngest, oldest = chop max_stunnel times' in
     let oldest_ids = List.map fst oldest in
     List.iter
-      (fun x -> 
-         let stunnel = Tbl.find !stunnels x in
-         debug "Expiring stunnel id %s since we have too many cached tunnels (limit is %d)" 
-           (id_of_stunnel stunnel) max_stunnel) oldest_ids;
+      (fun x ->
+        let stunnel = Tbl.find !stunnels x in
+        debug
+          "Expiring stunnel id %s since we have too many cached tunnels (limit \
+           is %d)"
+          (id_of_stunnel stunnel) max_stunnel)
+      oldest_ids ;
     to_gc := !to_gc @ oldest_ids
-  end;
+  ) ;
   (* Disconnect all stunnels we wish to GC *)
-  List.iter (fun id ->
+  List.iter
+    (fun id ->
       let s = Tbl.find !stunnels id in
-      Stunnel.disconnect s) !to_gc;
+      Stunnel.disconnect s)
+    !to_gc ;
   (* Remove all reference to them from our cache hashtables *)
   let index' = Hashtbl.create capacity in
   Hashtbl.iter
     (fun ep ids ->
-       let kept_ids = (List.filter (fun id -> not(List.mem id !to_gc)) ids) in
-       if kept_ids != [] then Hashtbl.add index' ep kept_ids
-       else ()
-    ) !index;
+      let kept_ids = List.filter (fun id -> not (List.mem id !to_gc)) ids in
+      if kept_ids != [] then
+        Hashtbl.add index' ep kept_ids
+      else
+        ())
+    !index ;
   let times' = Hashtbl.copy !times in
-  List.iter (fun idx -> Hashtbl.remove times' idx) !to_gc;
+  List.iter (fun idx -> Hashtbl.remove times' idx) !to_gc ;
   let stunnels' = Tbl.copy !stunnels in
-  List.iter (fun idx -> Tbl.remove stunnels' idx) !to_gc;
-
-  index := index';
-  times := times';
+  List.iter (fun idx -> Tbl.remove stunnels' idx) !to_gc ;
+  index := index' ;
+  times := times' ;
   stunnels := stunnels'
 
 let gc () = Mutex.execute m unlocked_gc
 
 let counter = ref 0
 
-let add (x: Stunnel.t) = 
+let add (x : Stunnel.t) =
   let now = Unix.gettimeofday () in
   Mutex.execute m (fun () ->
       let idx = !counter in
-      incr counter;
-      Hashtbl.add !times idx now;
-      Tbl.move_into !stunnels idx x;
-      let ep = { host = x.Stunnel.host; port = x.Stunnel.port; verified = x.Stunnel.verified } in
+      incr counter ;
+      Hashtbl.add !times idx now ;
+      Tbl.move_into !stunnels idx x ;
+      let ep =
+        {
+          host= x.Stunnel.host
+        ; port= x.Stunnel.port
+        ; verified= x.Stunnel.verified
+        }
+      in
       let existing =
-        if Hashtbl.mem !index ep
-        then Hashtbl.find !index ep
-        else [] in
-      Hashtbl.replace !index ep (idx :: existing);
-      debug "Adding stunnel id %s (idle %.2f) to the cache"
-        (id_of_stunnel x) 0.;
-      unlocked_gc ()
-  )
+        if Hashtbl.mem !index ep then
+          Hashtbl.find !index ep
+        else
+          []
+      in
+      Hashtbl.replace !index ep (idx :: existing) ;
+      debug "Adding stunnel id %s (idle %.2f) to the cache" (id_of_stunnel x) 0. ;
+      unlocked_gc ())
 
 (** Returns an Stunnel.t for this endpoint (oldest first), raising Not_found
     if none can be found. First performs a garbage-collection, which discards
     expired stunnels if needed. *)
 let with_remove host port verified f =
-  let ep = { host = host; port = port; verified = verified } in
-  let get_id () = Mutex.execute m
-      (fun () ->
-         unlocked_gc ();
-
-         let ids = Hashtbl.find !index ep in
-         let table = List.map (fun id -> id, Hashtbl.find !times id) ids in
-         let sorted = List.sort (fun a b -> compare (snd a) (snd b)) table in
-         match sorted with
-         | (id, time) :: _ ->
-           let stunnel = Tbl.find !stunnels id in
-           debug "Removing stunnel id %s (idle %.2f) from the cache"
-             (id_of_stunnel stunnel) (Unix.gettimeofday () -. time);
-           Hashtbl.remove !times id;
-           Hashtbl.replace !index ep (List.filter (fun x -> x <> id) ids);
-           id
-         | _ -> raise Not_found
-      ) in
+  let ep = {host; port; verified} in
+  let get_id () =
+    Mutex.execute m (fun () ->
+        unlocked_gc () ;
+        let ids = Hashtbl.find !index ep in
+        let table = List.map (fun id -> (id, Hashtbl.find !times id)) ids in
+        let sorted = List.sort (fun a b -> compare (snd a) (snd b)) table in
+        match sorted with
+        | (id, time) :: _ ->
+            let stunnel = Tbl.find !stunnels id in
+            debug "Removing stunnel id %s (idle %.2f) from the cache"
+              (id_of_stunnel stunnel)
+              (Unix.gettimeofday () -. time) ;
+            Hashtbl.remove !times id ;
+            Hashtbl.replace !index ep (List.filter (fun x -> x <> id) ids) ;
+            id
+        | _ ->
+            raise Not_found)
+  in
   let id_opt = try Some (get_id ()) with Not_found -> None in
-  id_opt |> Option.map @@ fun id ->
-  (* cannot call while holding above mutex or we deadlock *)
-  Tbl.with_find_moved_exn !stunnels id f
+  id_opt
+  |> Option.map @@ fun id ->
+     (* cannot call while holding above mutex or we deadlock *)
+     Tbl.with_find_moved_exn !stunnels id f
 
 (** Flush the cache - remove everything *)
 let flush () =
-  Mutex.execute m 
-    (fun () ->
-       info "Flushing cache of all %d stunnels." (Tbl.length !stunnels);
-       Tbl.iter !stunnels (fun _id st -> Stunnel.disconnect st);
-       Tbl.reset !stunnels;
-       Hashtbl.clear !times;
-       Hashtbl.clear !index;
-       info "Flushed!")
-
+  Mutex.execute m (fun () ->
+      info "Flushing cache of all %d stunnels." (Tbl.length !stunnels) ;
+      Tbl.iter !stunnels (fun _id st -> Stunnel.disconnect st) ;
+      Tbl.reset !stunnels ;
+      Hashtbl.clear !times ;
+      Hashtbl.clear !index ;
+      info "Flushed!")
 
 let with_connect ?use_fork_exec_helper ?write_to_log ?verify_cert host port f =
   let verify_cert = Stunnel.must_verify_cert verify_cert in
   match with_remove host port verify_cert f with
-  | Some r -> r
+  | Some r ->
+      r
   | None ->
-    info "connect did not find cached stunnel for endpoint %s:%d" host port;
-    Stunnel.with_connect ?use_fork_exec_helper ?write_to_log ~verify_cert host port f
+      info "connect did not find cached stunnel for endpoint %s:%d" host port ;
+      Stunnel.with_connect ?use_fork_exec_helper ?write_to_log ~verify_cert host
+        port f

--- a/stunnel/stunnel_cache.ml
+++ b/stunnel/stunnel_cache.ml
@@ -37,7 +37,7 @@ let ignore_log fmt = Printf.ksprintf (fun _ -> ()) fmt
 (* Use and overlay the definition from D. *)
 let debug = if debug_enabled then debug else ignore_log
 
-type endpoint = {host: string; port: int; verified: bool}
+type endpoint = {host: string; port: int; verified: Stunnel.config option}
 
 (* Need to limit the absolute number of stunnels as well as the maximum age *)
 let max_stunnel = 70
@@ -224,8 +224,7 @@ let flush () =
       Hashtbl.clear !index ;
       info "Flushed!")
 
-let with_connect ?use_fork_exec_helper ?write_to_log ?verify_cert host port f =
-  let verify_cert = Stunnel.must_verify_cert verify_cert in
+let with_connect ?use_fork_exec_helper ?write_to_log ~verify_cert host port f =
   match with_remove host port verify_cert f with
   | Some r ->
       r

--- a/stunnel/stunnel_cache.mli
+++ b/stunnel/stunnel_cache.mli
@@ -23,7 +23,7 @@
 val with_connect :
      ?use_fork_exec_helper:bool
   -> ?write_to_log:(string -> unit)
-  -> ?verify_cert:bool
+  -> verify_cert:Stunnel.config option
   -> string
   -> int
   -> (Stunnel.t -> 'b)
@@ -35,7 +35,8 @@ val with_connect :
 val add : Stunnel.t -> unit
 (** Adds a reusable stunnel to the cache *)
 
-val with_remove : string -> int -> bool -> (Stunnel.t -> 'b) -> 'b option
+val with_remove :
+  string -> int -> Stunnel.config option -> (Stunnel.t -> 'b) -> 'b option
 (** Given a host and port call a function with a cached stunnel, or return None. *)
 
 val flush : unit -> unit

--- a/stunnel/stunnel_cache.mli
+++ b/stunnel/stunnel_cache.mli
@@ -23,7 +23,7 @@
 val with_connect :
      ?use_fork_exec_helper:bool
   -> ?write_to_log:(string -> unit)
-  -> verify_cert:Stunnel.config option
+  -> verify_cert:Stunnel.verification_config option
   -> string
   -> int
   -> (Stunnel.t -> 'b)
@@ -36,7 +36,11 @@ val add : Stunnel.t -> unit
 (** Adds a reusable stunnel to the cache *)
 
 val with_remove :
-  string -> int -> Stunnel.config option -> (Stunnel.t -> 'b) -> 'b option
+     string
+  -> int
+  -> Stunnel.verification_config option
+  -> (Stunnel.t -> 'b)
+  -> 'b option
 (** Given a host and port call a function with a cached stunnel, or return None. *)
 
 val flush : unit -> unit

--- a/stunnel/stunnel_cache.mli
+++ b/stunnel/stunnel_cache.mli
@@ -20,23 +20,26 @@
      the connection should be kept-alive.
 *)
 
-
+val with_connect :
+     ?use_fork_exec_helper:bool
+  -> ?write_to_log:(string -> unit)
+  -> ?verify_cert:bool
+  -> string
+  -> int
+  -> (Stunnel.t -> 'b)
+  -> 'b
 (** Connects via stunnel (optionally via an external 'fork/exec helper') to
     a host and port. If there is a suitable stunnel in the cache then this 
     will be used, otherwise we make a fresh one. *)
-val with_connect :
-  ?use_fork_exec_helper:bool ->
-  ?write_to_log:(string -> unit) ->
-  ?verify_cert:bool -> string -> int -> (Stunnel.t -> 'b) -> 'b
 
-(** Adds a reusable stunnel to the cache *)
 val add : Stunnel.t -> unit
+(** Adds a reusable stunnel to the cache *)
 
-(** Given a host and port call a function with a cached stunnel, or return None. *)
 val with_remove : string -> int -> bool -> (Stunnel.t -> 'b) -> 'b option
+(** Given a host and port call a function with a cached stunnel, or return None. *)
 
-(** Empty the cache of all stunnels *)
 val flush : unit -> unit
+(** Empty the cache of all stunnels *)
 
-(** GCs old stunnels *)
 val gc : unit -> unit
+(** GCs old stunnels *)

--- a/stunnel/stunnel_client.ml
+++ b/stunnel/stunnel_client.ml
@@ -1,0 +1,32 @@
+(*
+ * Copyright (C) Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make (struct let name = "Stunnel_client" end)
+
+let verify = ref false
+
+let get_verify_by_default () = !verify
+
+let set_verify_by_default = function
+  | false ->
+      D.info "disabling default tls verification" ;
+      verify := false
+  | true ->
+      D.info "enabling default tls verification" ;
+      verify := true
+
+let pool () = match !verify with true -> Some Stunnel.pool | false -> None
+
+let appliance () =
+  match !verify with true -> Some Stunnel.appliance | false -> None

--- a/stunnel/stunnel_client.mli
+++ b/stunnel/stunnel_client.mli
@@ -1,0 +1,21 @@
+(*
+ * Copyright (C) Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val get_verify_by_default : unit -> bool
+
+val set_verify_by_default : bool -> unit
+
+val pool : unit -> Stunnel.config option
+
+val appliance : unit -> Stunnel.config option

--- a/stunnel/stunnel_client.mli
+++ b/stunnel/stunnel_client.mli
@@ -16,6 +16,6 @@ val get_verify_by_default : unit -> bool
 
 val set_verify_by_default : bool -> unit
 
-val pool : unit -> Stunnel.config option
+val pool : unit -> Stunnel.verification_config option
 
-val appliance : unit -> Stunnel.config option
+val appliance : unit -> Stunnel.verification_config option

--- a/uuid/uuid.ml
+++ b/uuid/uuid.ml
@@ -18,12 +18,14 @@ type 'a t = string
 type cookie = string
 
 let of_string s = s
+
 let to_string s = s
 
 let null = ""
 
 (* deprecated: we don't need to duplicate the uuid prefix/suffix *)
 let uuid_of_string = of_string
+
 let string_of_uuid = to_string
 
 let string_of_cookie s = s
@@ -31,69 +33,79 @@ let string_of_cookie s = s
 let cookie_of_string s = s
 
 let dev_random = "/dev/random"
+
 let dev_urandom = "/dev/urandom"
 
 let rnd_array n =
   let fstbyte i = 0xff land i in
   let sndbyte i = fstbyte (i lsr 8) in
   let thdbyte i = sndbyte (i lsr 8) in
-  let rec rnd_list n acc = match n with
-    | 0 -> acc
+  let rec rnd_list n acc =
+    match n with
+    | 0 ->
+        acc
     | 1 ->
-      let b = fstbyte (Random.bits ()) in
-      b :: acc
+        let b = fstbyte (Random.bits ()) in
+        b :: acc
     | 2 ->
-      let r = Random.bits () in
-      let b1 = fstbyte r in
-      let b2 = sndbyte r in
-      b1 :: b2 :: acc
-    | n -> 
-      let r = Random.bits () in
-      let b1 = fstbyte r in
-      let b2 = sndbyte r in
-      let b3 = thdbyte r in
-      rnd_list (n - 3) (b1 :: b2 :: b3 :: acc)
+        let r = Random.bits () in
+        let b1 = fstbyte r in
+        let b2 = sndbyte r in
+        b1 :: b2 :: acc
+    | n ->
+        let r = Random.bits () in
+        let b1 = fstbyte r in
+        let b2 = sndbyte r in
+        let b3 = thdbyte r in
+        rnd_list (n - 3) (b1 :: b2 :: b3 :: acc)
   in
   Array.of_list (rnd_list n [])
 
-let read_array dev n = 
+let read_array dev n =
   let fd = Unix.openfile dev [Unix.O_RDONLY] 0o640 in
   let finally body_f clean_f =
-    try 
-      let ret = body_f () in clean_f (); ret
-    with e -> clean_f (); raise e in
-  finally 
-    (fun () -> 
-       let buf = Bytes.create n in
-       let read = Unix.read fd buf 0 n in
-       if read <> n then raise End_of_file
-       else 
-         Array.init n (fun i -> Char.code (Bytes.get buf i))
-    )
+    try
+      let ret = body_f () in
+      clean_f () ; ret
+    with e -> clean_f () ; raise e
+  in
+  finally
+    (fun () ->
+      let buf = Bytes.create n in
+      let read = Unix.read fd buf 0 n in
+      if read <> n then
+        raise End_of_file
+      else
+        Array.init n (fun i -> Char.code (Bytes.get buf i)))
     (fun () -> Unix.close fd)
 
 let uuid_of_int_array uuid =
-  Printf.sprintf "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
-    uuid.(0) uuid.(1) uuid.(2) uuid.(3) uuid.(4) uuid.(5)
-    uuid.(6) uuid.(7) uuid.(8) uuid.(9) uuid.(10) uuid.(11)
-    uuid.(12) uuid.(13) uuid.(14) uuid.(15)
+  Printf.sprintf
+    "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
+    uuid.(0) uuid.(1) uuid.(2) uuid.(3) uuid.(4) uuid.(5) uuid.(6) uuid.(7)
+    uuid.(8) uuid.(9) uuid.(10) uuid.(11) uuid.(12) uuid.(13) uuid.(14)
+    uuid.(15)
 
 let make_uuid_prng () = uuid_of_int_array (rnd_array 16)
+
 let make_uuid_urnd () = uuid_of_int_array (read_array dev_urandom 16)
+
 let make_uuid_rnd () = uuid_of_int_array (read_array dev_random 16)
+
 let make_uuid = make_uuid_urnd
 
-let make_cookie() =
+let make_cookie () =
   let bytes = Array.to_list (read_array dev_urandom 64) in
   String.concat "" (List.map (Printf.sprintf "%1x") bytes)
 
 let int_array_of_uuid s =
   try
     let l = ref [] in
-    Scanf.sscanf s "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
+    Scanf.sscanf s
+      "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
       (fun a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 ->
-         l := [ a0; a1; a2; a3; a4; a5; a6; a7; a8; a9;
-                a10; a11; a12; a13; a14; a15; ]);
+        l :=
+          [a0; a1; a2; a3; a4; a5; a6; a7; a8; a9; a10; a11; a12; a13; a14; a15]) ;
     Array.of_list !l
   with _ -> invalid_arg "Uuid.int_array_of_uuid"
 

--- a/uuid/uuid.mli
+++ b/uuid/uuid.mli
@@ -25,36 +25,39 @@
 (** A 128-bit UUID.  Using phantom types ('a) to achieve the requires type-safety. *)
 type 'a t
 
-(** Create a fresh UUID *)
 val make_uuid : unit -> 'a t
+(** Create a fresh UUID *)
+
 val make_uuid_prng : unit -> 'a t
+
 val make_uuid_urnd : unit -> 'a t
+
 val make_uuid_rnd : unit -> 'a t
 
-(** Create a UUID from a string. *)
 val of_string : string -> 'a t
+(** Create a UUID from a string. *)
 
-(** Marshal a UUID to a string. *)
 val to_string : 'a t -> string
+(** Marshal a UUID to a string. *)
 
+val null : 'a t
 (** A null UUID, as if such a thing actually existed.  It turns out to be
  * useful though. *)
-val null : 'a t
 
-(** Deprecated alias for {! Uuid.of_string} *)
 val uuid_of_string : string -> 'a t
+(** Deprecated alias for {! Uuid.of_string} *)
 
-(** Deprecated alias for {! Uuid.to_string} *)
 val string_of_uuid : 'a t -> string
+(** Deprecated alias for {! Uuid.to_string} *)
 
-(** Convert an array to a UUID. *)
 val uuid_of_int_array : int array -> 'a t
+(** Convert an array to a UUID. *)
 
-(** Convert a UUID to an array. *)
 val int_array_of_uuid : 'a t -> int array
+(** Convert a UUID to an array. *)
 
-(** Check whether a string is a UUID. *)
 val is_uuid : string -> bool
+(** Check whether a string is a UUID. *)
 
 (** A 512-bit cookie. *)
 type cookie

--- a/xapi-compression/xapi_compression.ml
+++ b/xapi-compression/xapi_compression.ml
@@ -4,27 +4,31 @@ end
 
 open Xapi_stdext_pervasives.Pervasiveext
 
-module Make(Algorithm : ALGORITHM) = struct
+module Make (Algorithm : ALGORITHM) = struct
   let available () = Sys.file_exists Algorithm.executable
 
   type zcat_mode = Compress | Decompress
 
   type input_type =
-    | Active  (** we provide a function which writes into the compressor and a fd output *)
-    | Passive (** we provide an fd input and a function which reads from the compressor *)
+    | Active
+        (** we provide a function which writes into the compressor and a fd output *)
+    | Passive
+        (** we provide an fd input and a function which reads from the compressor *)
 
   (* start cmd with lowest priority so that it doesn't
      use up all cpu resources in dom0
   *)
   let lower_priority cmd args =
-    let ionice="/usr/bin/ionice" in
-    let ionice_args=["-c";"3"] in (*io idle*)
-    let nice="/bin/nice" in
-    let nice_args=["-n";"19"] in (*lowest priority*)
-    let extra_args=nice_args@[ionice]@ionice_args in
-    let new_cmd=nice in
-    let new_args=extra_args@[cmd]@args in
-    (new_cmd,new_args)
+    let ionice = "/usr/bin/ionice" in
+    let ionice_args = ["-c"; "3"] in
+    (*io idle*)
+    let nice = "/bin/nice" in
+    let nice_args = ["-n"; "19"] in
+    (*lowest priority*)
+    let extra_args = nice_args @ [ionice] @ ionice_args in
+    let new_cmd = nice in
+    let new_args = extra_args @ [cmd] @ args in
+    (new_cmd, new_args)
 
   (** Runs a zcat process which is either:
       i) a compressor; or (ii) a decompressor
@@ -32,48 +36,66 @@ module Make(Algorithm : ALGORITHM) = struct
       i) an active input (ie a function and a pipe) + passive output (fd); or
       ii) a passive input (fd) + active output (ie a function and a pipe)
   *)
-  let go (mode: zcat_mode) (input: input_type) fd f =
+  let go (mode : zcat_mode) (input : input_type) fd f =
     let open Safe_resources in
     Unixfd.with_pipe ~loc:__LOC__ () @@ fun zcat_out zcat_in ->
-
-         let args = if mode = Compress then [] else ["--decompress"] @ [ "--stdout"; "--force" ] in
-
-         let stdin, stdout, close_now, close_later = match input with
-           | Active ->
-             Some Unixfd.(!zcat_out),                              (* input comes from the pipe+fn *)
-             Some fd,                                    (* supplied fd is written to *)
-             zcat_out,                                   (* we close this now *)
-             zcat_in                                     (* close this before waitpid *)
-           | Passive ->
-             Some fd,                                    (* supplied fd is read from *)
-             Some Unixfd.(!zcat_in),                               (* output goes into the pipe+fn *)
-             zcat_in,                                    (* we close this now *)
-             zcat_out in                                 (* close this before waitpid *)
-         let (executable,args)=lower_priority Algorithm.executable args in
-         let pid = Forkhelpers.safe_close_and_exec stdin stdout None [] executable args in
-
-         Unixfd.safe_close close_now;
-         finally
-           (fun () ->
-              f Unixfd.(!close_later)
-           )
-           (fun () ->
-              let failwith_error s =
-                let mode = if mode = Compress then "Compression" else "Decompression" in
-                let msg = Printf.sprintf "%s via zcat failed: %s" mode s in
-                Printf.eprintf "%s" msg;
-                failwith msg
-              in
-              Unixfd.safe_close close_later;
-              let open Xapi_stdext_unix in
-              match snd (Forkhelpers.waitpid pid) with
-              | Unix.WEXITED 0 -> ();
-              | Unix.WEXITED i -> failwith_error (Printf.sprintf "exit code %d" i)
-              | Unix.WSIGNALED i -> failwith_error (Printf.sprintf "killed by signal: %s" (Unixext.string_of_signal i))
-              | Unix.WSTOPPED i -> failwith_error (Printf.sprintf "stopped by signal: %s" (Unixext.string_of_signal i))
-           )
+    let args =
+      if mode = Compress then [] else ["--decompress"] @ ["--stdout"; "--force"]
+    in
+    let stdin, stdout, close_now, close_later =
+      match input with
+      | Active ->
+          ( Some Unixfd.(!zcat_out)
+          , (* input comes from the pipe+fn *)
+            Some fd
+          , (* supplied fd is written to *)
+            zcat_out
+          , (* we close this now *)
+            zcat_in )
+          (* close this before waitpid *)
+      | Passive ->
+          ( Some fd
+          , (* supplied fd is read from *)
+            Some Unixfd.(!zcat_in)
+          , (* output goes into the pipe+fn *)
+            zcat_in
+          , (* we close this now *)
+            zcat_out )
+    in
+    (* close this before waitpid *)
+    let executable, args = lower_priority Algorithm.executable args in
+    let pid =
+      Forkhelpers.safe_close_and_exec stdin stdout None [] executable args
+    in
+    Unixfd.safe_close close_now ;
+    finally
+      (fun () -> f Unixfd.(!close_later))
+      (fun () ->
+        let failwith_error s =
+          let mode =
+            if mode = Compress then "Compression" else "Decompression"
+          in
+          let msg = Printf.sprintf "%s via zcat failed: %s" mode s in
+          Printf.eprintf "%s" msg ; failwith msg
+        in
+        Unixfd.safe_close close_later ;
+        let open Xapi_stdext_unix in
+        match snd (Forkhelpers.waitpid pid) with
+        | Unix.WEXITED 0 ->
+            ()
+        | Unix.WEXITED i ->
+            failwith_error (Printf.sprintf "exit code %d" i)
+        | Unix.WSIGNALED i ->
+            failwith_error
+              (Printf.sprintf "killed by signal: %s"
+                 (Unixext.string_of_signal i))
+        | Unix.WSTOPPED i ->
+            failwith_error
+              (Printf.sprintf "stopped by signal: %s"
+                 (Unixext.string_of_signal i)))
 
   let compress fd f = go Compress Active fd f
+
   let decompress fd f = go Decompress Active fd f
 
   let decompress_passive fd f = go Decompress Passive fd f

--- a/xapi-compression/xapi_compression.mli
+++ b/xapi-compression/xapi_compression.mli
@@ -3,17 +3,17 @@ module type ALGORITHM = sig
 end
 
 module Make : functor (Algorithm : ALGORITHM) -> sig
+  val available : unit -> bool
   (** Returns whether this compression algorithm is available *)
-  val available: unit -> bool
 
+  val compress : Unix.file_descr -> (Unix.file_descr -> unit) -> unit
   (** Runs a compression process which is fed from a pipe whose entrance is passed to 'f'
       and whose output is 'ofd' *)
-  val compress: Unix.file_descr -> (Unix.file_descr -> unit) -> unit
 
+  val decompress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
   (** Runs a decompression process which is fed from a pipe whose entrance is passed to 'f'
       and whose output is 'ofd' *)
-  val decompress: Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
 
   (* Experimental decompressor which is fed from an fd and writes to a pipe *)
-  val decompress_passive: Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
+  val decompress_passive : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
 end

--- a/xml-light2/xml.mli
+++ b/xml-light2/xml.mli
@@ -11,32 +11,43 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
+
 (** tree representation *)
 type xml =
   | Element of (string * (string * string) list * xml list)
   | PCData of string
 
 type error_pos
+
 type error = string * error_pos
 
 exception Error of error
 
 val error : error -> string
 
-(** input functions *)
 val parse_file : string -> xml
+(** input functions *)
+
 val parse_in : in_channel -> xml
+
 val parse_string : string -> xml
 
-(** output functions *)
 val to_fct : xml -> (string -> unit) -> unit
+(** output functions *)
+
 val to_fct_fmt : xml -> (string -> unit) -> unit
+
 val to_string : xml -> string
+
 val to_string_fmt : xml -> string
 
 (** helper functions *)
 exception Not_pcdata of string
+
 exception Not_element of string
+
 val pcdata : xml -> string
+
 val children : xml -> xml list
+
 val tag : xml -> string

--- a/zstd/zstd.ml
+++ b/zstd/zstd.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Zstd = Xapi_compression.Make(struct
+module Zstd = Xapi_compression.Make (struct
   (** Path to the zstd binary *)
   let executable = "/usr/bin/zstd"
 end)

--- a/zstd/zstd.mli
+++ b/zstd/zstd.mli
@@ -12,13 +12,13 @@
  * GNU Lesser General Public License for more details.
  *)
 
+val compress : Unix.file_descr -> (Unix.file_descr -> unit) -> unit
 (** Runs a compression process which is fed from a pipe whose entrance is passed to 'f'
     and whose output is 'ofd' *)
-val compress: Unix.file_descr -> (Unix.file_descr -> unit) -> unit
 
+val decompress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
 (** Runs a decompression process which is fed from a pipe whose entrance is passed to 'f'
     and whose output is 'ofd' *)
-val decompress: Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
 
 (* Experimental decompressor which is fed from an fd and writes to a pipe *)
-val decompress_passive: Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
+val decompress_passive : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a


### PR DESCRIPTION
Connections may use TLS verification but the details depend on the
configuration. This patch introduces a type Stunnel.config which
describes the details to be used for verification, if at all. A value of
this type needs to be threaded through the code to create to correct
Stunnel client configuration.
