### PR TITLE
xapi-compression: change misleading error message

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,2 @@
 (lang dune 1.11)
-(allow_approximate_merlin)
 (using fmt 1.2 (enabled_for ocaml))

--- a/http-svr/dune
+++ b/http-svr/dune
@@ -10,7 +10,8 @@
               rpclib
               sha
               stunnel
-              threads
+              threads.posix
+              xapi-idl
               xapi-idl.updates
               xapi-stdext-date
               xapi-stdext-pervasives

--- a/http-svr/http.ml
+++ b/http-svr/http.ml
@@ -192,7 +192,8 @@ let parse_keyvalpairs xs =
       | k :: vs ->
           (urldecode k, urldecode (String.concat "=" vs))
       | [] ->
-          raise Http_parse_failure)
+          raise Http_parse_failure
+      )
     kvpairs
 
 let parse_uri x =
@@ -407,8 +408,9 @@ module Accept = struct
     ; (* None means '*' *)
       subty: string option
     ; (* None means '*' *)
-      q: int (* range 0 - 1000 *)
-             (* We won't parse the more advanced stuff *)
+      q: int
+          (* range 0 - 1000 *)
+          (* We won't parse the more advanced stuff *)
   }
 
   let string_of_t x =
@@ -476,7 +478,8 @@ module Accept = struct
               | Some (k, v) ->
                   (k, v)
               | _ ->
-                  raise (Parse_failure x))
+                  raise (Parse_failure x)
+              )
             params
         in
         let q =
@@ -737,7 +740,8 @@ module Response = struct
       x.frame x.version x.code x.message
       (Option.fold ~none:"None"
          ~some:(fun x -> "Some " ^ Int64.to_string x)
-         x.content_length)
+         x.content_length
+      )
       (Option.fold ~none:"None" ~some:(fun x -> "Some " ^ x) x.task)
       (kvpairs x.additional_headers)
 
@@ -874,12 +878,14 @@ module Url = struct
         | _ ->
             failwith
               (Printf.sprintf "Failed to parse authentication substring: %s"
-                 uname_password)
+                 uname_password
+              )
       )
       | _ ->
           failwith
             (Printf.sprintf
-               "Failed to parse username password host and port: %s" x)
+               "Failed to parse username password host and port: %s" x
+            )
     in
     let reconstruct_uri uri = "/" ^ String.concat "/" uri in
     let data_of_uri uri =

--- a/http-svr/http_client.ml
+++ b/http-svr/http_client.ml
@@ -144,7 +144,8 @@ let response_of_fd_exn fd =
                    error "Failed to parse HTTP response status line [%s]" header ;
                    raise
                      (Parse_error
-                        (Printf.sprintf "Failed to parse %s" http_version))
+                        (Printf.sprintf "Failed to parse %s" http_version)
+                     )
              )
              | None ->
                  raise (Parse_error (Printf.sprintf "Failed to parse %s" rest))
@@ -166,12 +167,15 @@ let response_of_fd_exn fd =
                      {
                        res with
                        additional_headers= (k, v) :: res.additional_headers
-                     } )
+                     }
+               )
              )
            | _ ->
-               (true, res) (* end of headers? *))
+               (true, res) (* end of headers? *)
+         )
        (false, empty)
-       (Astring.String.cuts ~sep:"\n" buf))
+       (Astring.String.cuts ~sep:"\n" buf)
+    )
 
 (** [response_of_fd fd] returns an optional Http.Response.t record *)
 let response_of_fd ?(use_fastpath = false) fd =

--- a/http-svr/http_proxy.ml
+++ b/http-svr/http_proxy.ml
@@ -68,7 +68,8 @@ let http_proxy src_ip src_port transport =
         let request = Http_svr.request_of_bio bio in
         Option.iter
           (fun request -> with_transport transport (one request fromfd))
-          request)
+          request
+        )
       (fun () -> Unix.close fromfd)
   in
   try
@@ -101,7 +102,8 @@ let http_proxy src_ip src_port transport =
             raise e
         ) ;
         let s = Server_io.server handler sock in
-        server := Some s)
+        server := Some s
+    )
   with e ->
     error "Caught exception setting up proxy from internal network: %s"
       (Printexc.to_string e) ;

--- a/http-svr/http_svr.ml
+++ b/http-svr/http_svr.ml
@@ -57,7 +57,8 @@ module Stats = struct
     Mutex.execute m (fun () ->
         x.n_requests <- x.n_requests + 1 ;
         if req.Http.Request.close then x.n_connections <- x.n_connections + 1 ;
-        if req.Http.Request.frame then x.n_framed <- x.n_framed + 1)
+        if req.Http.Request.frame then x.n_framed <- x.n_framed + 1
+    )
 end
 
 (** Type of a function which can handle a Request.t *)
@@ -111,7 +112,8 @@ let response_fct req ?(hdrs = []) s (response_length : int64)
 let response_str req ?hdrs s body =
   let length = String.length body in
   response_fct req ?hdrs s (Int64.of_int length) (fun s ->
-      Unixext.really_write_string s body)
+      Unixext.really_write_string s body
+  )
 
 let response_missing ?(hdrs = []) s body =
   let connection = (Http.Hdr.connection, "close") in
@@ -181,7 +183,8 @@ let response_method_not_implemented ?req s =
     Option.fold ~none:""
       ~some:(fun req ->
         Printf.sprintf "<p>%s not supported.<br /></p>"
-          (Http.string_of_method_t req.Http.Request.m))
+          (Http.string_of_method_t req.Http.Request.m)
+        )
       req
   in
   let body =
@@ -207,7 +210,8 @@ let response_file ?mime_content_type s file =
   Unixext.with_file file [Unix.O_RDONLY] 0 (fun f ->
       Unixext.really_write_string s (Http.Response.to_wire_string res) ;
       let (_ : int64) = Unixext.copy_file f s in
-      ())
+      ()
+  )
 
 let respond_to_options req s =
   let access_control_allow_headers =
@@ -222,7 +226,8 @@ let respond_to_options req s =
         ("Access-Control-Allow-Origin", "*")
       ; ("Access-Control-Allow-Headers", access_control_allow_headers)
       ; ("Access-Control-Allow-Methods", "PUT")
-      ] s 0L (fun _ -> ())
+      ] s 0L (fun _ -> ()
+  )
 
 (** If no handler matches the request then call this callback *)
 let default_callback req bio _ =
@@ -482,10 +487,12 @@ let request_of_bio_exn bio =
                      {
                        req with
                        additional_headers= (k, v) :: req.additional_headers
-                     } )
+                     }
+               )
              )
            | None ->
-               (true, req) (* end of headers *))
+               (true, req) (* end of headers *)
+         )
        (false, {empty with Http.Request.frame; additional_headers})
   |> snd
 
@@ -532,10 +539,12 @@ let request_of_bio ?(use_fastpath = false) ic =
             response_internal_error ss
               ~extra:
                 (Printf.sprintf "Got UNIX error: %s %s %s"
-                   (Unix.error_message a) b c)
+                   (Unix.error_message a) b c
+                )
         | exc ->
             response_internal_error ss ~extra:(escape (Printexc.to_string exc)) ;
-            log_backtrace ()) ;
+            log_backtrace ()
+    ) ;
     None
 
 let handle_one (x : 'a Server.t) ss context req =
@@ -584,11 +593,13 @@ let handle_one (x : 'a Server.t) ss context req =
             response_internal_error ~req ss
               ~extra:
                 (Printf.sprintf "Got UNIX error: %s %s %s"
-                   (Unix.error_message a) b c)
+                   (Unix.error_message a) b c
+                )
         | exc ->
             response_internal_error ~req ss
               ~extra:(escape (Printexc.to_string exc)) ;
-            log_backtrace ()) ;
+            log_backtrace ()
+    ) ;
     !finished
 
 let handle_connection (x : 'a Server.t) _ ss =
@@ -696,7 +707,8 @@ let read_body ?limit req bio =
       let length = Int64.to_int length in
       Option.fold ~none:()
         ~some:(fun l ->
-          if length > l then raise Client_requested_size_over_limit)
+          if length > l then raise Client_requested_size_over_limit
+          )
         limit ;
       if Buf_io.is_buffer_empty bio then
         Unixext.really_read_string (Buf_io.fd_of bio) length

--- a/http-svr/http_test.ml
+++ b/http-svr/http_test.ml
@@ -86,7 +86,8 @@ let test_radix_tree1 _ =
   List.iter
     (fun x ->
       if longest_prefix x t <> Some x then
-        failwith (Printf.sprintf "x = %s" x))
+        failwith (Printf.sprintf "x = %s" x)
+      )
     test_strings
 
 let test_radix_tree2 _ =
@@ -164,8 +165,10 @@ let cross xs ys zs =
          ys
          |> List.fold_left
               (fun acc y ->
-                zs |> List.fold_left (fun acc z -> (x, y, z) :: acc) acc)
-              acc)
+                zs |> List.fold_left (fun acc z -> (x, y, z) :: acc) acc
+                )
+              acc
+         )
        []
 
 let test_read_http_request_header _ =
@@ -201,7 +204,9 @@ let test_read_http_request_header _ =
              in
              assert (actual_frame = frame) ;
              assert (actual_header = header) ;
-             assert (actual_proxy = if proxy then Some proxy_str else None)))
+             assert (actual_proxy = if proxy then Some proxy_str else None)
+         )
+     )
 
 let _ =
   let suite =

--- a/http-svr/mime.ml
+++ b/http-svr/mime.ml
@@ -30,13 +30,13 @@ let mime_of_file file =
         | [] | [_] ->
             ()
         | mime :: exts ->
-            List.iter (fun e -> Hashtbl.add h (lowercase e) mime) exts)
+            List.iter (fun e -> Hashtbl.add h (lowercase e) mime) exts
+      )
     file ;
   h
 
 let string_of_mime m =
-  String.concat ","
-    (Hashtbl.fold (fun k v a -> sprintf "{%s:%s}" k v :: a) m [])
+  String.concat "," (Hashtbl.fold (fun k v a -> sprintf "{%s:%s}" k v :: a) m [])
 
 let default_mime = "text/plain"
 

--- a/http-svr/radix_tree_test.ml
+++ b/http-svr/radix_tree_test.ml
@@ -47,7 +47,8 @@ let check1 () =
   List.iter
     (fun x ->
       if longest_prefix x t <> Some x then
-        failwith (Printf.sprintf "x = %s" x))
+        failwith (Printf.sprintf "x = %s" x)
+      )
     test_strings
 
 let check2 () =

--- a/http-svr/server_io.ml
+++ b/http-svr/server_io.ml
@@ -118,8 +118,10 @@ let server handler sock =
               establish_server ~signal_fds:[status_out]
                 (handler_by_thread handler)
                 (Server_fd sock)
-            with PleaseClose -> debug "Server thread exiting")
-          ())
+            with PleaseClose -> debug "Server thread exiting"
+            )
+          ()
+        )
       ()
   in
   let shutdown () =
@@ -127,7 +129,8 @@ let server handler sock =
       (fun () ->
         let len = Unix.write status_in (Bytes.of_string "!") 0 1 in
         if len <> 1 then failwith "Failed to signal to server to shutdown" ;
-        Thread.join thread)
+        Thread.join thread
+        )
       (fun () -> List.iter close' !toclose)
   in
   {shutdown}

--- a/http-svr/test_client.ml
+++ b/http-svr/test_client.ml
@@ -30,7 +30,8 @@ let with_stunnel ip port f =
 let one ~use_fastpath ~use_framing keep_alive s =
   Http_client.rpc ~use_fastpath s
     (Http.Request.make ~frame:use_framing ~version:"1.1" ~keep_alive ~user_agent
-       ~body:"hello" Http.Post "/echo") (fun response s ->
+       ~body:"hello" Http.Post "/echo"
+    ) (fun response s ->
       match response.Http.Response.content_length with
       | Some l ->
           let (_ : string) = Unixext.really_read_string s (Int64.to_int l) in
@@ -40,7 +41,8 @@ let one ~use_fastpath ~use_framing keep_alive s =
 *)
           ()
       | None ->
-          failwith "Need a content length")
+          failwith "Need a content length"
+  )
 
 module Normal_population = struct
   (** Stats on a normally-distributed population *)
@@ -116,7 +118,9 @@ let _ =
   let nonpersistent =
     sample 1 (fun () ->
         per_nsec 1. (fun () ->
-            transport !ip !port (one ~use_fastpath ~use_framing false)))
+            transport !ip !port (one ~use_fastpath ~use_framing false)
+        )
+    )
   in
   Printf.printf "%s RPCs/sec\n%!" (Normal_population.to_string nonpersistent) ;
   Printf.printf "10 threads non-persistent connections: " ;
@@ -124,7 +128,10 @@ let _ =
     sample 1 (fun () ->
         threads 10 (fun () ->
             per_nsec 5. (fun () ->
-                transport !ip !port (one ~use_fastpath ~use_framing false))))
+                transport !ip !port (one ~use_fastpath ~use_framing false)
+            )
+        )
+    )
   in
   Printf.printf "%s RPCs/sec\n%!"
     (Normal_population.to_string thread_nonpersistent) ;
@@ -132,7 +139,9 @@ let _ =
   let persistent =
     sample 1 (fun () ->
         transport !ip !port (fun s ->
-            per_nsec 1. (fun () -> one ~use_fastpath ~use_framing true s)))
+            per_nsec 1. (fun () -> one ~use_fastpath ~use_framing true s)
+        )
+    )
   in
   Printf.printf "%s RPCs/sec\n%!" (Normal_population.to_string persistent) ;
   Printf.printf "10 threads persistent connections: " ;
@@ -140,7 +149,9 @@ let _ =
     sample 1 (fun () ->
         threads 10 (fun () ->
             transport !ip !port (fun s ->
-                per_nsec 5. (fun () -> one ~use_fastpath ~use_framing true s))))
+                per_nsec 5. (fun () -> one ~use_fastpath ~use_framing true s)
+            )
+        )
+    )
   in
-  Printf.printf "%s RPCs/sec\n%!"
-    (Normal_population.to_string thread_persistent)
+  Printf.printf "%s RPCs/sec\n%!" (Normal_population.to_string thread_persistent)

--- a/http-svr/test_server.ml
+++ b/http-svr/test_server.ml
@@ -27,7 +27,10 @@ let _ =
          Unixext.really_write_string s r ;
          Mutex.execute finished_m (fun () ->
              finished := true ;
-             Condition.signal finished_c))) ;
+             Condition.signal finished_c
+         )
+         )
+    ) ;
   Server.add_handler server Http.Post "/echo"
     (FdIO
        (fun request s _ ->
@@ -35,14 +38,17 @@ let _ =
          | None ->
              Unixext.really_write_string s
                (Http.Response.to_wire_string
-                  (Http.Response.make "404" "content length missing"))
+                  (Http.Response.make "404" "content length missing")
+               )
          | Some l ->
              let txt = Unixext.really_read_string s (Int64.to_int l) in
              let r =
                Http.Response.to_wire_string
                  (Http.Response.make ~body:txt "200" "OK")
              in
-             Unixext.really_write_string s r)) ;
+             Unixext.really_write_string s r
+         )
+    ) ;
   Server.add_handler server Http.Get "/stats"
     (FdIO
        (fun _ s _ ->
@@ -51,15 +57,17 @@ let _ =
              (fun (m, uri, s) ->
                Printf.sprintf "%s,%s,%d,%d\n"
                  (Http.string_of_method_t m)
-                 uri s.Http_svr.Stats.n_requests s.Http_svr.Stats.n_connections)
+                 uri s.Http_svr.Stats.n_requests s.Http_svr.Stats.n_connections
+               )
              (Server.all_stats server)
          in
          let txt = String.concat "" lines in
          let r =
-           Http.Response.to_wire_string
-             (Http.Response.make ~body:txt "200" "OK")
+           Http.Response.to_wire_string (Http.Response.make ~body:txt "200" "OK")
          in
-         Unixext.really_write_string s r)) ;
+         Unixext.really_write_string s r
+         )
+    ) ;
   let ip = "0.0.0.0" in
   let inet_addr = Unix.inet_addr_of_string ip in
   let addr = Unix.ADDR_INET (inet_addr, !port) in
@@ -69,6 +77,7 @@ let _ =
   Mutex.execute finished_m (fun () ->
       while not !finished do
         Condition.wait finished_c finished_m
-      done) ;
+      done
+  ) ;
   Printf.printf "Exiting\n" ;
   stop socket

--- a/http-svr/ws_helpers.ml
+++ b/http-svr/ws_helpers.ml
@@ -128,7 +128,8 @@ let hixie_v76_upgrade req s =
     ^ String.concat "&"
         (List.map
            (fun (x, y) -> Printf.sprintf "%s=%s" x y)
-           req.Http.Request.query)
+           req.Http.Request.query
+        )
   in
   let headers = http_101_websocket_upgrade_76 origin host protocol real_uri in
   Http.output_http s headers ;

--- a/http-svr/xMLRPC.ml
+++ b/http-svr/xMLRPC.ml
@@ -148,7 +148,8 @@ module From = struct
     | xml ->
         rtte
           (Printf.sprintf "unbox: %s should contain '%s'" (pretty_print xml)
-             (List.hd ok))
+             (List.hd ok)
+          )
           xml
 
   let singleton ok f xml =
@@ -160,8 +161,10 @@ module From = struct
             rtte
               (Printf.sprintf "singleton: {%s} should be the singleton {%s}"
                  (String.concat ", " (List.map pretty_print y))
-                 (List.hd ok))
-              xml)
+                 (List.hd ok)
+              )
+              xml
+        )
       xml
 
   let pair ok f1 f2 xml =
@@ -180,7 +183,8 @@ module From = struct
             debug "encountered <name/> within a <structure>" ;
             f ""
         | _ ->
-            rtte "From.name: should contain PCData" xml)
+            rtte "From.name: should contain PCData" xml
+        )
       xml
 
   (* let check expected xml got =
@@ -257,6 +261,7 @@ module From = struct
         | Xml.Element ("fault", _, _) as xml ->
             Fault (fault id xml)
         | xml ->
-            rtte "response" xml)
+            rtte "response" xml
+        )
       xml
 end

--- a/pciutil/pciutil.ml
+++ b/pciutil/pciutil.ml
@@ -50,7 +50,8 @@ let parse_from file vendor device =
         current_xvendor := String.sub line 0 4 ;
         if !current_xvendor = vendor then
           vendor_str := Some (String.sub line 6 (String.length line - 6))
-      ))
+      )
+      )
     file ;
   (!vendor_str, !device_str)
 

--- a/resources/table.ml
+++ b/resources/table.ml
@@ -32,12 +32,14 @@ struct
         | None ->
             Hashtbl.add t k v
         | Some old ->
-            V.safe_release old ; Hashtbl.replace t k v)
+            V.safe_release old ; Hashtbl.replace t k v
+    )
 
   let remove (t, m) k =
     Mutex.execute m (fun () ->
         Option.iter V.safe_release (Hashtbl.find_opt t k) ;
-        Hashtbl.remove t k)
+        Hashtbl.remove t k
+    )
 
   let find (t, m) k = Mutex.execute m (fun () -> Hashtbl.find t k)
 
@@ -45,7 +47,8 @@ struct
     let v =
       Mutex.execute m (fun () ->
           let r = Hashtbl.find t k in
-          Hashtbl.remove t k ; r)
+          Hashtbl.remove t k ; r
+      )
     in
     V.with_moved_exn v
 

--- a/resources/test/safe_test.ml
+++ b/resources/test/safe_test.ml
@@ -35,7 +35,9 @@ let test_can_release t =
   Alcotest.(
     check_raises "use-after-release" Safe.UseAfterMoveOrRelease (fun () ->
         let (_ : Counting.t) = Safe.borrow_exn t in
-        ()))
+        ()
+    )
+  )
 
 let test_can_release2 t =
   let counter = Safe.borrow_exn t in
@@ -45,7 +47,9 @@ let test_can_release2 t =
   Alcotest.(
     check_raises "use-after-release" Safe.UseAfterMoveOrRelease (fun () ->
         let (_ : Counting.t) = Safe.borrow_exn t in
-        ()))
+        ()
+    )
+  )
 
 let test_can_move_release t =
   let counter = Safe.borrow_exn t in
@@ -60,18 +64,21 @@ let test_can_move_release t =
 let test_borrow_exn_after_release t =
   Safe.safe_release t ;
   Alcotest.check_raises "use-after-release" Safe.UseAfterMoveOrRelease
-    (fun () -> Safe.borrow_exn t |> Counting.get |> ignore)
+    (fun () -> Safe.borrow_exn t |> Counting.get |> ignore
+  )
 
 let test_move_exn_after_release t =
   Safe.safe_release t ;
   Alcotest.check_raises "use-after-release" Safe.UseAfterMoveOrRelease
-    (fun () -> Safe.move_exn t |> ignore)
+    (fun () -> Safe.move_exn t |> ignore
+  )
 
 let test_release_after_move t =
   let counter = Safe.borrow_exn t in
   let t' = Safe.move_exn t in
   Alcotest.check_raises "use-after-move" Safe.UseAfterMoveOrRelease (fun () ->
-      Safe.borrow_exn t |> Counting.get |> ignore) ;
+      Safe.borrow_exn t |> Counting.get |> ignore
+  ) ;
   Safe.safe_release t ;
   Alcotest.(check int "dropped" 0 (Counting.get counter)) ;
   Safe.safe_release t' ;
@@ -81,7 +88,8 @@ let tests =
   List.map
     (fun (loc, f) ->
       let t = SafeCounting.create () in
-      (loc, `Quick, fun () -> f t))
+      (loc, `Quick, fun () -> f t)
+      )
     [
       (__LOC__, test_can_borrow)
     ; (__LOC__, test_can_release)

--- a/resources/test/unixfd_test.ml
+++ b/resources/test/unixfd_test.ml
@@ -36,7 +36,8 @@ let run () =
       (* this is intentionally buggy here: it leaks.
        * GC finaliser should detect, warn and clean up *)
       Safe.move_exn p1 |> ignore ;
-      Safe.move_exn p2 |> ignore)
+      Safe.move_exn p2 |> ignore
+  )
 
 let leak_detected (count0, count1, count2) =
   (* do not call alcotest inhere, it gives weird results with memory getting freed,
@@ -53,7 +54,8 @@ let noleak2 () =
   let moved1, moved2 =
     count0 := count_fds () ;
     Unixfd.with_pipe ~loc:__LOC__ () (fun p1 p2 ->
-        (Safe.move_exn p1, Safe.move_exn p2))
+        (Safe.move_exn p1, Safe.move_exn p2)
+    )
   in
   count1 := count_fds () ;
   Safe.within (Safe.move_exn moved1) @@ ignore ;
@@ -105,14 +107,17 @@ let test_unixfd_leak_detected =
 let validate_result
     {memory; memory_growth; fds_before; fds_after; fds_after_cleanup} () =
   Logs.debug (fun m ->
-      m "Memory usage (words): %d -> %d" memory (memory + memory_growth)) ;
+      m "Memory usage (words): %d -> %d" memory (memory + memory_growth)
+  ) ;
   Alcotest.(check int "memory leak in words" 0 memory_growth) ;
   match (fds_before, fds_after, fds_after_cleanup) with
   | Some before, Some after, Some after_cleanup ->
       Alcotest.(
-        check int "count of open FDs after pipe 2 higher" (before + 2) after) ;
+        check int "count of open FDs after pipe 2 higher" (before + 2) after
+      ) ;
       Alcotest.(
-        check int "count of open FDs same as original" before after_cleanup)
+        check int "count of open FDs same as original" before after_cleanup
+      )
   | None, None, None ->
       ()
   | _ ->

--- a/resources/unixfd.ml
+++ b/resources/unixfd.ml
@@ -50,7 +50,8 @@ let with_fd alloc = alloc () |> within
 let with_open_connection addr ~loc f =
   let open Unix in
   with_fd ~loc (fun () ->
-      socket ~cloexec:true (domain_of_sockaddr addr) SOCK_STREAM 0)
+      socket ~cloexec:true (domain_of_sockaddr addr) SOCK_STREAM 0
+  )
   @@ fun s -> connect !s addr ; f s
 
 let with_ic fd =
@@ -58,8 +59,7 @@ let with_ic fd =
    * Unix.open_connection does this but if you close both channels you get EBADF.
    *)
   Safe.within
-  @@ Safe.create ~release:close_in_noerr
-       (Unix.in_channel_of_descr (Unix.dup fd))
+  @@ Safe.create ~release:close_in_noerr (Unix.in_channel_of_descr (Unix.dup fd))
 
 let with_oc fd =
   Safe.within

--- a/sexpr/dune
+++ b/sexpr/dune
@@ -8,7 +8,7 @@
   (wrapped false)
   (modules (:standard \ sexprpp))
   (libraries astring
-             threads
+             threads.posix
              xapi-stdext-threads)
 )
 

--- a/sexpr/sExpr.ml
+++ b/sexpr/sExpr.ml
@@ -50,7 +50,8 @@ let escape s =
         | _ ->
             Astring.String.of_char c
       in
-      Buffer.add_string escaped c')
+      Buffer.add_string escaped c'
+      )
     s ;
   Buffer.contents escaped
 

--- a/sexpr/sExpr_TS.ml
+++ b/sexpr/sExpr_TS.ml
@@ -16,6 +16,7 @@ let lock = Mutex.create ()
 
 let of_string s =
   Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
-      SExprParser.expr SExprLexer.token (Lexing.from_string s))
+      SExprParser.expr SExprLexer.token (Lexing.from_string s)
+  )
 
 let string_of = SExpr.string_of

--- a/stunnel/stunnel.ml
+++ b/stunnel/stunnel.ml
@@ -257,7 +257,8 @@ let disconnect ?(wait = true) ?(force = false) x =
           else
             Forkhelpers.waitpid_nohang
           )
-            fpid)
+            fpid
+          )
         pid_int
   | StdFork pid ->
       do_disc
@@ -267,7 +268,8 @@ let disconnect ?(wait = true) ?(force = false) x =
           else
             Unix.waitpid [Unix.WNOHANG]
           )
-            pid)
+            pid
+          )
         pid
   | Nopid ->
       ()
@@ -329,14 +331,17 @@ let with_attempt_one_connect ?unique_id ?(use_fork_exec_helper = true)
                 (Forkhelpers.safe_close_and_exec
                    (Some Unixfd.(!data_in))
                    (Some Unixfd.(!data_in))
-                   (Some logfd) configs path args)
+                   (Some logfd) configs path args
+                )
           else
             StdFork
               (Unsafe.fork_and_exec
                  ~pre_exec:(fun _ ->
                    List.iter Unsafe.do_fd_operation fdops ;
-                   Unixext.close_all_fds_except fds_needed)
-                 (path :: args))
+                   Unixext.close_all_fds_except fds_needed
+                   )
+                 (path :: args)
+              )
           ) ;
         Unixfd.safe_close config_out ;
         Unixfd.safe_close data_in ;
@@ -354,8 +359,10 @@ let with_attempt_one_connect ?unique_id ?(use_fork_exec_helper = true)
             (Printf.sprintf
                "Caught Unix.Unix_error(%s, %s, %s); raising \
                 Stunnel_initialisation_failed"
-               (Unix.error_message err) fn arg) ;
-          raise Stunnel_initialisation_failed)
+               (Unix.error_message err) fn arg
+            ) ;
+          raise Stunnel_initialisation_failed
+    )
   in
   (* Tidy up any remaining unclosed fds *)
   match result with
@@ -399,7 +406,8 @@ let with_connect ?unique_id ?use_fork_exec_helper ?write_to_log ~verify_cert
   retry
     (fun () ->
       with_attempt_one_connect ?unique_id ?use_fork_exec_helper ?write_to_log
-        verify_cert extended_diagnosis host port f)
+        verify_cert extended_diagnosis host port f
+      )
     5
 
 let check_verify_error line =
@@ -415,7 +423,8 @@ let check_verify_error line =
     | Some e ->
         raise
           (Stunnel_verify_error
-             (split_1 "," (sub_after (e + String.length "error=") line)))
+             (split_1 "," (sub_after (e + String.length "error=") line))
+          )
     | None ->
         raise (Stunnel_verify_error "")
   else

--- a/stunnel/stunnel_cache.ml
+++ b/stunnel/stunnel_cache.ml
@@ -87,7 +87,8 @@ let unlocked_gc () =
       debug "Cache contents: %s"
         (Hashtbl.fold
            (fun ep xs acc -> string_of_index ep xs ^ " " ^ acc)
-           !index "")
+           !index ""
+        )
   ) ;
   (* Split a list at the given index to give a pair of lists.
    *  From Xapi_stdext_std.Listext *)
@@ -116,7 +117,8 @@ let unlocked_gc () =
         debug "Expiring stunnel id %s; idle (%.2f) > limit (%.2f)"
           (id_of_stunnel stunnel) age max_idle ;
         to_gc := idx :: !to_gc
-      )) ;
+      )
+  ) ;
   let num_remaining = List.length all_ids - List.length !to_gc in
   if num_remaining > max_stunnel then (
     let times' = Hashtbl.fold (fun k v acc -> (k, v) :: acc) !times [] in
@@ -133,7 +135,8 @@ let unlocked_gc () =
         debug
           "Expiring stunnel id %s since we have too many cached tunnels (limit \
            is %d)"
-          (id_of_stunnel stunnel) max_stunnel)
+          (id_of_stunnel stunnel) max_stunnel
+        )
       oldest_ids ;
     to_gc := !to_gc @ oldest_ids
   ) ;
@@ -141,7 +144,8 @@ let unlocked_gc () =
   List.iter
     (fun id ->
       let s = Tbl.find !stunnels id in
-      Stunnel.disconnect s)
+      Stunnel.disconnect s
+      )
     !to_gc ;
   (* Remove all reference to them from our cache hashtables *)
   let index' = Hashtbl.create capacity in
@@ -151,7 +155,8 @@ let unlocked_gc () =
       if kept_ids != [] then
         Hashtbl.add index' ep kept_ids
       else
-        ())
+        ()
+      )
     !index ;
   let times' = Hashtbl.copy !times in
   List.iter (fun idx -> Hashtbl.remove times' idx) !to_gc ;
@@ -187,7 +192,8 @@ let add (x : Stunnel.t) =
       in
       Hashtbl.replace !index ep (idx :: existing) ;
       debug "Adding stunnel id %s (idle %.2f) to the cache" (id_of_stunnel x) 0. ;
-      unlocked_gc ())
+      unlocked_gc ()
+  )
 
 (** Returns an Stunnel.t for this endpoint (oldest first), raising Not_found
     if none can be found. First performs a garbage-collection, which discards
@@ -210,7 +216,8 @@ let with_remove host port verified f =
             Hashtbl.replace !index ep (List.filter (fun x -> x <> id) ids) ;
             id
         | _ ->
-            raise Not_found)
+            raise Not_found
+    )
   in
   let id_opt = try Some (get_id ()) with Not_found -> None in
   id_opt
@@ -226,7 +233,8 @@ let flush () =
       Tbl.reset !stunnels ;
       Hashtbl.clear !times ;
       Hashtbl.clear !index ;
-      info "Flushed!")
+      info "Flushed!"
+  )
 
 let with_connect ?use_fork_exec_helper ?write_to_log ~verify_cert host port f =
   match with_remove host port verify_cert f with

--- a/uuid/uuid.ml
+++ b/uuid/uuid.ml
@@ -76,7 +76,8 @@ let read_array dev n =
       if read <> n then
         raise End_of_file
       else
-        Array.init n (fun i -> Char.code (Bytes.get buf i)))
+        Array.init n (fun i -> Char.code (Bytes.get buf i))
+      )
     (fun () -> Unix.close fd)
 
 let uuid_of_int_array uuid =
@@ -105,7 +106,8 @@ let int_array_of_uuid s =
       "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
       (fun a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 ->
         l :=
-          [a0; a1; a2; a3; a4; a5; a6; a7; a8; a9; a10; a11; a12; a13; a14; a15]) ;
+          [a0; a1; a2; a3; a4; a5; a6; a7; a8; a9; a10; a11; a12; a13; a14; a15]
+    ) ;
     Array.of_list !l
   with _ -> invalid_arg "Uuid.int_array_of_uuid"
 
@@ -113,5 +115,6 @@ let is_uuid str =
   try
     Scanf.sscanf str
       "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
-      (fun _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ -> true)
+      (fun _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ -> true
+    )
   with _ -> false

--- a/xapi-compression/dune
+++ b/xapi-compression/dune
@@ -4,6 +4,7 @@
   (libraries forkexec
              threads
              safe-resources
+             xapi-idl
              xapi-stdext-pervasives
              xapi-stdext-unix)
 )

--- a/xapi-compression/xapi_compression.ml
+++ b/xapi-compression/xapi_compression.ml
@@ -55,7 +55,8 @@ module Make (Algorithm : ALGORITHM) = struct
           , (* supplied fd is written to *)
             zcat_out
           , (* we close this now *)
-            zcat_in )
+            zcat_in
+          )
           (* close this before waitpid *)
       | Passive ->
           ( Some fd
@@ -64,7 +65,8 @@ module Make (Algorithm : ALGORITHM) = struct
           , (* output goes into the pipe+fn *)
             zcat_in
           , (* we close this now *)
-            zcat_out )
+            zcat_out
+          )
     in
     (* close this before waitpid *)
     let executable, args = lower_priority Algorithm.executable args in
@@ -99,11 +101,14 @@ module Make (Algorithm : ALGORITHM) = struct
         | Unix.WSIGNALED i ->
             failwith_error
               (Printf.sprintf "killed by signal: %s"
-                 (Unixext.string_of_signal i))
+                 (Unixext.string_of_signal i)
+              )
         | Unix.WSTOPPED i ->
             failwith_error
               (Printf.sprintf "stopped by signal: %s"
-                 (Unixext.string_of_signal i)))
+                 (Unixext.string_of_signal i)
+              )
+        )
 
   let compress fd f = go Compress Active fd f
 

--- a/xml-light2/xml.ml
+++ b/xml-light2/xml.ml
@@ -114,7 +114,8 @@ let esc_pcdata data =
         | _ ->
             ""
       in
-      Buffer.add_string buf s)
+      Buffer.add_string buf s
+      )
     data ;
   Buffer.contents buf
 


### PR DESCRIPTION
Previously it always stated zcat file while ignoring the actual name of
the executable used. Now it's taken into account when generating the
error. The error is now logged instead of output to stderr.

This also contains tweaks to the dune metadata, making it less reliable
on implicit dependencies. The merlin approximate mode is not needed
because .merlin files aren't generated anymore.Previously it always stated zcat file while ignoring the actual name of
the executable used. Now it's taken into account when generating the
error. The error is now logged instead of output to stderr.

This also contains tweaks to the dune metadata, making it less reliable
on implicit dependencies. The merlin approximate mode is not needed
because .merlin files aren't generated anymore.