### PR TITLE
CA-358583: Fix PROXY metadata to multiple HTTPS requests on a connection

### DIFF
--- a/http-svr/http_proxy.ml
+++ b/http-svr/http_proxy.ml
@@ -65,7 +65,7 @@ let http_proxy src_ip src_port transport =
     finally
       (fun () ->
         let bio = Buf_io.of_fd fromfd in
-        let request = Http_svr.request_of_bio bio in
+        let request, _ = Http_svr.request_of_bio bio in
         Option.iter
           (fun request -> with_transport transport (one request fromfd))
           request

--- a/http-svr/http_svr.mli
+++ b/http-svr/http_svr.mli
@@ -126,4 +126,8 @@ val headers : Unix.file_descr -> string list -> unit
 
 val read_body : ?limit:int -> Http.Request.t -> Buf_io.t -> string
 
-val request_of_bio : ?use_fastpath:bool -> Buf_io.t -> Http.Request.t option
+val request_of_bio :
+     ?use_fastpath:bool
+  -> ?proxy_seen:string
+  -> Buf_io.t
+  -> Http.Request.t option * string option


### PR DESCRIPTION
When stunnel is configured with `protocol = proxy`, it will send a PROXY
header right at the beginning after establishing a connection to the
server, before passing on any decrypted data from the client. This
header contains useful TCP parameters, such as the source IP (see
04dd088). Even if this connection ends up carrying multiple HTTP(S)
requests, there will only be one PROXY header sent, as stunnel doesn't
interpret the data.

The HTTP server, however, looks for the PROXY header and HTTP header in
one step. So the first request on the connection gets annotated with
this PROXY data, and any following requests on the same connection do
not. It doesn't remember that it had already seen the PROXY header. This
is easily fixed in the receive loop by passing on a PROXY header once
one has been seen.

Fixes: https://github.com/xapi-project/xen-api/issues/4517

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>