### PR TITLE
CP-41796 Close Port 80 (Encrypt Data Transfer During VM Migrations)

### DIFF
--- a/http-svr/http.ml
+++ b/http-svr/http.ml
@@ -1000,4 +1000,6 @@ module Url = struct
 
   let auth_of (scheme, _) =
     match scheme with File _ -> None | Http {auth; _} -> auth
+
+  let set_ssl ssl = function Http h, d -> (Http {h with ssl}, d) | x -> x
 end

--- a/http-svr/http.mli
+++ b/http-svr/http.mli
@@ -268,4 +268,6 @@ module Url : sig
   val get_query : t -> string
 
   val auth_of : t -> authorization option
+
+  val set_ssl : bool -> t -> t
 end

--- a/http-svr/xmlrpc_client.ml
+++ b/http-svr/xmlrpc_client.ml
@@ -304,7 +304,7 @@ let transport_of_url (scheme, _) =
       let port = Opt.default 443 h.port in
       SSL (SSL.make (), h.host, port)
 
-let with_transport transport f =
+let with_transport ?(stunnel_wait_disconnect = true) transport f =
   let open Xapi_stdext_unix in
   match transport with
   | Unix path ->
@@ -376,7 +376,7 @@ let with_transport transport f =
                   s_pid use_stunnel_cache
               ) else (
                 Unix.unlink st_proc.Stunnel.logfile ;
-                Stunnel.disconnect st_proc
+                Stunnel.disconnect ~wait:stunnel_wait_disconnect st_proc
               )
             )
       )

--- a/http-svr/xmlrpc_client.mli
+++ b/http-svr/xmlrpc_client.mli
@@ -46,7 +46,8 @@ val transport_of_url : Http.Url.t -> transport
 val string_of_transport : transport -> string
 (** [string_of_transport t] returns a debug-friendly version of [t] *)
 
-val with_transport : transport -> (Unix.file_descr -> 'a) -> 'a
+val with_transport :
+  ?stunnel_wait_disconnect:bool -> transport -> (Unix.file_descr -> 'a) -> 'a
 (** [with_transport transport f] calls [f fd] with [fd] connected via
     	the requested [transport] *)
 


### PR DESCRIPTION
Backport 65f95bddc0b6906787866af7f80d3a2a243d6cd6
Backport 7e440d68d739391eb34a8861732571bc8dfddf13

When starting a mirroring process for a disk as part of a storage migration, xapi establishes the connection to the destination, but hands it over to tapdisk to do the actual mirroring over NBD. It is crucial that xapi just hands over the file descriptor and then continues with other business, without waiting for the connection to finish. This is how it works for TCP connections now.

When switching to TLS connections, xapi starts an stunnel process as part of the connection setup, and hands over the stunnel fd to tapdisk. By default, this functionality then waits for stunnel to finish after the connection is eventually broken, thus introducing the unwanted blocking. We fix this by telling stunnel to disconnect, but not wait for this to actually happen.