### PR TITLE
CA-379173 handle race condition in stunnel_cache

### DIFF
--- a/stunnel/stunnel_cache.ml
+++ b/stunnel/stunnel_cache.ml
@@ -106,18 +106,22 @@ let unlocked_gc () =
   (* Find the ones which are too old *)
   let now = Unix.gettimeofday () in
   Tbl.iter !stunnels (fun idx stunnel ->
-      let time = Hashtbl.find !times idx in
-      let idle = now -. time in
-      let age = now -. stunnel.Stunnel.connected_time in
-      if age > max_age then (
-        debug "Expiring stunnel id %s; age (%.2f) > limit (%.2f)"
-          (id_of_stunnel stunnel) age max_age ;
-        to_gc := idx :: !to_gc
-      ) else if idle > max_idle then (
-        debug "Expiring stunnel id %s; idle (%.2f) > limit (%.2f)"
-          (id_of_stunnel stunnel) age max_idle ;
-        to_gc := idx :: !to_gc
-      )
+      match Hashtbl.find_opt !times idx with
+      | Some time ->
+          let idle = now -. time in
+          let age = now -. stunnel.Stunnel.connected_time in
+          if age > max_age then (
+            debug "Expiring stunnel id %s; age (%.2f) > limit (%.2f)"
+              (id_of_stunnel stunnel) age max_age ;
+            to_gc := idx :: !to_gc
+          ) else if idle > max_idle then (
+            debug "Expiring stunnel id %s; idle (%.2f) > limit (%.2f)"
+              (id_of_stunnel stunnel) age max_idle ;
+            to_gc := idx :: !to_gc
+          )
+      | None ->
+          let __FUNCTION__ = "unlocked_gc" in
+          debug "%s: found no entry for idx=%d" __FUNCTION__ idx
   ) ;
   let num_remaining = List.length all_ids - List.length !to_gc in
   if num_remaining > max_stunnel then (


### PR DESCRIPTION
Backport from xen-api.git where stunnel is today: https://github.com/xapi-project/xen-api/pull/5077

We haev seen a hash table lookup fail unexpectedly. Handle this gracefully.

This does not fix the underlying race condition. The current code strikes me as quite challenging to improve in this regard.